### PR TITLE
🐛 fix for middleware functionality on lambda

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --fix .",
     "test:unit": "cross-env NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar REGION=us-west-1 tape test/unit/**/*-test.js test/unit/**/**/*-test.js | tap-spec",
     "test:integration": "cross-env NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar REGION=us-west-1 tape test/integration/*-test.js | tap-spec",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "test": "npm run lint && npm run test:integration && npm run coverage",
     "clean": "rm -rf ./src/http/get-index"
   },

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -10,7 +10,7 @@ function addMiddleware(...steps) {
     for (let step of steps) {
       // Running step ${step.name}
       var middleWareResult = await step(request, context)
-      var isRequest = middleWareResult && middleWareResult.hasOwnProperty('method')
+      var isRequest = middleWareResult && middleWareResult.hasOwnProperty('httpMethod')
       if (isRequest) {
         // Middleware ${step.name} has returned a modified request, continuing...
         request = middleWareResult

--- a/test/unit/middleware/index-test.js
+++ b/test/unit/middleware/index-test.js
@@ -14,25 +14,41 @@ test('arc.middleware should allow for munging and passing a request object betwe
     return { statusCode: 200, body: req.body }
   }
   let handler = middleware(one, two)
-  handler({method: 'GET'})
+  handler({httpMethod: 'GET'})
 })
+
 test('arc.middleware should prevent further middleware processing when a response is returned', t => {
   t.plan(1)
   let one = function () { return { statusCode: 200 } }
   let two = sinon.fake()
   let handler = middleware(one, two)
-  handler({method: 'GET'})
+  handler({httpMethod: 'GET'})
   t.notOk(two.callCount, 'second middleware not called')
 })
+
 test('arc.middleware should throw if no middleware returns a response', async t => {
   t.plan(1)
   let one = function (req) { return req }
   let two = function (req) { return req }
   let handler = middleware(one, two)
   try {
-    await handler({method: 'GET'})
+    await handler({httpMethod: 'GET'})
   } catch (e) {
     t.ok(e, 'exception thrown')
     t.end()
   }
+})
+
+test('arc.middleware should pass original request if layer does not return anything', async t => {
+  t.plan(1)
+  let one = function () { return }
+  let two = sinon.fake.returns({statusCode: 200})
+  let request = {httpMethod: 'GET', querystringParameters: {q: 'poop'}}
+  let handler = middleware(one, two)
+  try {
+    await handler(request)
+  } catch (e) {
+    t.fail(e, 'exception thrown')
+  }
+  t.ok(two.calledWith(request), 'second middleware layer called with origin request object')
 })


### PR DESCRIPTION
Fixed middleware not working when deployed to lambda. Lambda request objects do not have a `method` property, only an `httpMethod` property. Request objects in sandbox has both. See architect/sandbox#17 for more discussion on the issue.

This closes #45.

✅ also added test for unmodified request passing in middleware.