### PR TITLE
Fix for AWS errors

### DIFF
--- a/src/ws/send-old.js
+++ b/src/ws/send-old.js
@@ -48,10 +48,9 @@ module.exports = function WS(event) {
       }
       else {
         let apiVersion = '2018-11-29'
-        let apiId = event.requestContext.apiId
-        let region = process.env.AWS_REGION
-        let stage = process.env.NODE_ENV
-        let endpoint = `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}`
+        let domainName = event.requestContext.domainName
+        let stage = event.requestContext.stage
+        let endpoint = `${domainName}/${event.requestContext.stage}`
         let gateway = new aws.ApiGatewayManagementApi({apiVersion, endpoint})
         gateway.postToConnection({
           ConnectionId: id,

--- a/src/ws/send-old.js
+++ b/src/ws/send-old.js
@@ -50,7 +50,7 @@ module.exports = function WS(event) {
         let apiVersion = '2018-11-29'
         let domainName = event.requestContext.domainName
         let stage = event.requestContext.stage
-        let endpoint = `${domainName}/${event.requestContext.stage}`
+        let endpoint = `${domainName}/${stage}`
         let gateway = new aws.ApiGatewayManagementApi({apiVersion, endpoint})
         gateway.postToConnection({
           ConnectionId: id,


### PR DESCRIPTION
This is a potential fix for the issue I've described in #130. I'm unsure what the route cause is, but after debugging the current ws.send implementation I noticed the endpoint was constructed differently to that in an example (AWS blog post|https://aws.amazon.com/blogs/compute/announcing-websocket-apis-in-amazon-api-gateway/).

I was dubious about putting this forward as a pull request because, whilst it works for me, because I don't understand the underlying issue, this could be a weird fix that works for me but not others.

Additionally I suspect that's very good reason the previous implementation stitched the URL together using the environment vars rather than grabbing parameters from the event...?