### PR TITLE
fix for arc.static

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -1,105 +1,19 @@
-let fs = require('fs')
-let path = require('path')
-let url = require('url').format
-let readLocalArc = require('../utils/read-local-arc')
-let arc
+const {readFileSync, existsSync} = require('fs')
+const {join} = require('path')
 
 /**
- * Architect static asset helper
- * - Returns the live asset filename
- *
- * In order to keep this method sync, it does not use reflection to get fingerprint status
- * - Checking @static fingerprint true is something we used to do reading the .arc file
- * - No longer doing this is vaguely more dangerous, so we'll do checks to ensure assetPath validity
- * - ? TODO: add fingerprint state to env vars in Arc 6 to restore safety in that configuration?
+ * @param {string} path - the path to the asset (eg. /index.js)
+ * @returns {string} path - the resolved asset path (eg. /_static/index-xxx.js)
  */
-module.exports = function _static(assetPath, options) {
-  // Normalize to no leading slash
-  if (assetPath[0] === '/') assetPath = assetPath.substring(1)
-
-  // Env stuff
-  let env = process.env.NODE_ENV
-  let runningLocally = !env || env === 'testing' || process.env.ARC_LOCAL
-
-  let staticManifest
-  let folder = process.env.ARC_STATIC_FOLDER
-    ? '/' + process.env.ARC_STATIC_FOLDER
-    : ''
-  let region = process.env.AWS_REGION
-  let S3domain = bucket => `https://${bucket}.s3.${region}.amazonaws.com${folder}/`
-
-  // TODO add options
-  // - fingerprinted filename only (nice for proxy uses)
-  // - force serving from /_static
-  // - CDN / alternate domain prefix
-
-  // Just pass through request if not in staging or production
-  if (runningLocally) {
-    return `/_static/${assetPath}`
+module.exports = function _static(path) {
+  let key = path[0] === '/'? path.substring(1) : path
+  let manifest = join(process.cwd(), 'node_modules', '@architect', 'shared', 'static.json')
+  let exists = existsSync(manifest)
+  let local = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
+  if (!local && exists) {
+    let read = p=> readFileSync(p).toString()
+    let pkg = JSON.parse(read(manifest))
+    return `/_static/${pkg[key]}`
   }
-  else {
-    // Infer fingerprint status from presence of static.json in shared
-    let staticManifestFile = path.join(process.cwd(), 'node_modules', '@architect', 'shared', 'static.json')
-    if (fs.existsSync(staticManifestFile)) {
-      try {
-        staticManifest = JSON.parse(fs.readFileSync(staticManifestFile))
-      }
-      catch(e) {
-        throw ReferenceError('Could not parse static.json (asset fingerprint manifest)')
-      }
-    }
-
-    // Rewrite the file path with the fingerprinted filename
-    if (staticManifest)
-      assetPath = staticManifest[assetPath]
-
-    // Potentially detect filename conflict jic
-    if (!assetPath) {
-      throw ReferenceError('Could not find asset in static.json (asset fingerprint manifest)')
-    }
-    /**
-     * Static env var takes precedence if present
-     *   Generally, but not exclusively, Arc 6+
-     */
-    else if (process.env.ARC_STATIC_BUCKET) {
-      let raw = S3domain(process.env.ARC_STATIC_BUCKET) + assetPath
-      return url(raw)
-    }
-    /**
-     * Fall back to local .arc files ()
-     *   Generally !Arc 6+
-     */
-    else {
-      // Only load the arc file once (if possible)
-      if (!arc || options && options.reload) {
-        arc = readLocalArc()
-      }
-      if (arc && !arc.static) {
-        throw ReferenceError('Cannot return static asset path without @static pragma configured in Architect project manifest')
-      }
-      else {
-        let bucket = getBucket(arc.static)
-        let raw = S3domain(bucket) + assetPath
-        return url(raw)
-      }
-    }
-  }
-}
-
-// Helper returns the @static value for the current NODE_ENV
-function getBucket(_static) {
-  let staging
-  let production
-  _static.forEach(thing=> {
-    if (thing[0] === 'staging') {
-      staging = thing[1]
-    }
-    if (thing[0] === 'production') {
-      production = thing[1]
-    }
-  })
-  if (process.env.NODE_ENV === 'staging')
-    return staging
-  if (process.env.NODE_ENV === 'production')
-    return production
+  return `/_static/${key}`
 }

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -2,6 +2,13 @@ const {readFileSync, existsSync} = require('fs')
 const {join} = require('path')
 
 /**
+ * Architect static asset helper
+ * - Returns the live asset filename
+ *
+ * In order to keep this method sync, it does not use reflection to get fingerprint status
+ * - Not checking @static fingerprint true (which we used to read from the .arc file) is possibly dangerous, so ensure asset path is valid
+ * - ? TODO: add fingerprint state to env vars in Arc 6 to restore safety in that configuration?
+ *
  * @param {string} path - the path to the asset (eg. /index.js)
  * @returns {string} path - the resolved asset path (eg. /_static/index-xxx.js)
  */
@@ -13,7 +20,10 @@ module.exports = function _static(path) {
   if (!local && exists) {
     let read = p=> readFileSync(p).toString()
     let pkg = JSON.parse(read(manifest))
-    return `/_static/${pkg[key]}`
+    let asset = pkg[key]
+    if (!asset)
+      throw ReferenceError('Could not find asset in static.json (asset fingerprint manifest)')
+    return `/_static/${asset}`
   }
   return `/_static/${key}`
 }

--- a/test/integration/static-a-plain-filenames-test.js
+++ b/test/integration/static-a-plain-filenames-test.js
@@ -42,49 +42,11 @@ test('Local URL tests', t=> {
   t.equal(arc.static('index.html'), '/_static/index.html', 'Basic local static path (env=testing)')
 
   process.env.NODE_ENV = 'staging'
-  t.notEqual(arc.static('index.html'), '/_static/index.html', 'Basic local static path not used in staging')
+  t.equal(arc.static('index.html'), '/_static/index.html', 'Always use /_static')
 
   delete process.env.NODE_ENV // Run it "locally"
   process.env.ARC_STATIC_FOLDER = 'foo'
   t.equal(arc.static('index.html'), '/_static/index.html', 'Basic local static path unaffected by ARC_STATIC_FOLDER env var')
-  resetEnv()
-})
-
-test('Staging and production URL tests (fingerprint disabled by lack of @architect/shared/static.json)', t=> {
-  t.plan(5)
-  process.env.AWS_REGION = 'us-west-1'
-  process.env.NODE_ENV = 'production'
-  t.equals(arc.static('index.html'), 'https://a-production-bucket.s3.us-west-1.amazonaws.com/index.html', 'Production URL matches')
-  t.equals(arc.http.helpers.static('index.html'), 'https://a-production-bucket.s3.us-west-1.amazonaws.com/index.html', 'Production URL matches (legacy)')
-
-  process.env.NODE_ENV = 'staging'
-  t.equals(arc.static('index.html'), 'https://a-staging-bucket.s3.us-west-1.amazonaws.com/index.html', 'Staging URL matches')
-
-  process.env.ARC_STATIC_BUCKET = 'a-totally-different-bucket'
-  t.equals(arc.static('index.html'), 'https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/index.html', 'ARC_STATIC_BUCKET env var populates and matches')
-
-  process.env.ARC_STATIC_FOLDER = 'a-folder'
-  t.equals(arc.static('index.html'), 'https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/a-folder/index.html', 'ARC_STATIC_FOLDER env var populates and matches')
-  resetEnv()
-})
-
-test('Staging and production URL tests (fingerprint inferred by @architect/shared/static.json)', t=> {
-  t.plan(6)
-  process.env.AWS_REGION = 'us-west-1'
-  process.env.NODE_ENV = 'production'
-  fs.copyFileSync(join(mock, 'mock-static'), join(shared, 'static.json'))
-  t.ok(exists(join(shared, 'static.json')), 'Mock static.json file ready')
-  t.equals(arc.static('index.html'), 'https://a-production-bucket.s3.us-west-1.amazonaws.com/index-1e25d663f6.html', 'Production URL matches')
-  t.equals(arc.http.helpers.static('index.html'), 'https://a-production-bucket.s3.us-west-1.amazonaws.com/index-1e25d663f6.html', 'Production URL matches (legacy)')
-
-  process.env.NODE_ENV = 'staging'
-  t.equals(arc.static('index.html'), 'https://a-staging-bucket.s3.us-west-1.amazonaws.com/index-1e25d663f6.html', 'Staging URL matches')
-
-  process.env.ARC_STATIC_BUCKET = 'a-totally-different-bucket'
-  t.equals(arc.static('index.html'), 'https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/index-1e25d663f6.html', 'ARC_STATIC_BUCKET env var populates and matches')
-
-  process.env.ARC_STATIC_FOLDER = 'a-folder'
-  t.equals(arc.static('index.html'), 'https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/a-folder/index-1e25d663f6.html', 'ARC_STATIC_FOLDER env var populates and matches')
   resetEnv()
 })
 

--- a/test/integration/static-b-fingerprinted-filenames-test.js
+++ b/test/integration/static-b-fingerprinted-filenames-test.js
@@ -31,7 +31,7 @@ test('Fingerprinting only enabled if static manifest is found', t=> {
   process.env.AWS_REGION = 'us-west-1'
   process.env.NODE_ENV = 'production'
   arc.static('index.html', {reload:true})
-  t.equals(arc.static('index.html'), `https://a-production-bucket.s3.us-west-1.amazonaws.com/index.html`)
+  t.equals(arc.static('index.html'), `/_static/index.html`)
 })
 
 test('Set up mocked static manifest', t=> {
@@ -41,20 +41,6 @@ test('Set up mocked static manifest', t=> {
   // eslint-disable-next-line
   static = require(join(shared, 'static.json'))
   t.ok(static['index.html'], 'Static manifest loaded')
-})
-
-test('Staging and production fingerprinted URL tests', t=> {
-  t.plan(4)
-  t.equals(arc.static('index.html'), `https://a-production-bucket.s3.us-west-1.amazonaws.com/${static['index.html']}`, 'Production fingerprinted URL matches')
-
-  process.env.NODE_ENV = 'staging'
-  t.equals(arc.static('index.html'), `https://a-staging-bucket.s3.us-west-1.amazonaws.com/${static['index.html']}`, 'Staging fingerprinted URL matches')
-
-  process.env.ARC_STATIC_BUCKET = 'a-totally-different-bucket'
-  t.equals(arc.static('index.html'), `https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/${static['index.html']}`, 'Fingerprinted ARC_STATIC_BUCKET env var populates and matches')
-
-  process.env.ARC_STATIC_FOLDER = 'a-folder'
-  t.equals(arc.static('index.html'), `https://a-totally-different-bucket.s3.us-west-1.amazonaws.com/a-folder/${static['index.html']}`, 'Fingerprinted ARC_STATIC_FOLDER env var populates and matches')
 })
 
 test('Clean up env', t=> {


### PR DESCRIPTION
current implementation returns a fully qualified path to an S3 bucket however because we do not configure CORS on static buckets files cannot be loaded. this PR returns a path qualified from `/_static` proxy so assets can be loaded on the same origin. 