### PR TITLE
Allow setting session ttl via SESSION_TTL env var

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 ---
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
+## [3.4.14] 2019-12-13
+
+### Changed
+
+- Allow setting session TTL by passing a SESSION_TTL environment variable with the desired TTL in seconds
 
 ## [3.4.13] 2019-12-10
 

--- a/src/http/session/providers/ddb/index.js
+++ b/src/http/session/providers/ddb/index.js
@@ -66,7 +66,7 @@ function write(params, callback) {
       callback(err)
     }
     else {
-      let maxAge = 7.884e+8
+      let maxAge = process.env.SESSION_TTL || 7.884e+8
       let options = {
         maxAge,
         expires: new Date(Date.now() + maxAge * 1000),

--- a/src/http/session/providers/jwe.js
+++ b/src/http/session/providers/jwe.js
@@ -53,7 +53,7 @@ function write(payload, callback) {
   }
   let key = '_idx'
   let val = jwe.create(payload)
-  let maxAge = 7.884e+8
+  let maxAge = process.env.SESSION_TTL || 7.884e+8
   let options = {
     maxAge,
     expires: new Date(Date.now() + maxAge * 1000),

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -11,8 +11,9 @@ test('http.session apis exist', t=> {
 })
 
 test('jwe read and write implementations', async t=> {
-  t.plan(3)
+  t.plan(4)
   process.env.SESSION_TABLE_NAME = 'jwe'
+  process.env.SESSION_TTL = 14400
   let fakerequest = {}
   let session = await read(fakerequest)
   t.ok(session, 'read session cookie')
@@ -24,6 +25,7 @@ test('jwe read and write implementations', async t=> {
   t.comment(JSON.stringify(cookie))
   t.comment(JSON.stringify(inception))
   t.ok(inception.one === 1, 'read back again')
+  t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
 let end
@@ -35,8 +37,9 @@ test('set up sandbox for ddb testing', async t=> {
 })
 
 test('ddb read and write implementations', async t=> {
-  t.plan(3)
+  t.plan(4)
   process.env.SESSION_TABLE_NAME = 'arc-sessions'
+  process.env.SESSION_TTL = 14400
   let fakerequest = {}
   let session = await read(fakerequest)
   t.ok(session, 'read session cookie')
@@ -48,6 +51,7 @@ test('ddb read and write implementations', async t=> {
   t.comment(JSON.stringify(cookie))
   t.comment(JSON.stringify(inception))
   t.equals(inception.one, 1, 'read back modified cookie')
+  t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
 test('shutdown sandbox', async t=> {


### PR DESCRIPTION
Session duration is currently hard-coded to one week. This change allows specifying a session duration (in seconds) in a SESSION_TTL environment variable. If no variable is passed, the default remains in place.