### PR TITLE
Calling `static()` with the root path returns `/_static/`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,15 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
 
-## [3.7.5 - 3.7.7] 2020-02-13
+## [3.7.7] 2020-03-12
+
+### Fixed
+
+- Calling `static()` with the root path (e.g. `static('/')`) now returns `/_static/`; thanks Paul!
+
+---
+
+## [3.7.5 - 3.7.6] 2020-02-13
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "3.7.6",
+  "version": "3.7.7-RC.0",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
   "repository": {

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -12,13 +12,14 @@ const {join} = require('path')
  * @returns {string} path - the resolved asset path (eg. /_static/index-xxx.js)
  */
 module.exports = function _static(asset, options={}) {
-  let key = asset[0] === '/'? asset.substring(1) : asset
+  let key = asset[0] === '/' ? asset.substring(1) : asset
+  let isIndex = asset === '/'
   let manifest = join(process.cwd(), 'node_modules', '@architect', 'shared', 'static.json')
   let exists = existsSync(manifest)
   let local = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
   let stagePath = options.stagePath && !local ? '/' + process.env.NODE_ENV : ''
   let path = `${stagePath}/_static`
-  if (!local && exists) {
+  if (!local && exists && !isIndex) {
     let read = p=> readFileSync(p).toString()
     let pkg = JSON.parse(read(manifest))
     let asset = pkg[key]
@@ -26,5 +27,5 @@ module.exports = function _static(asset, options={}) {
       throw ReferenceError('Could not find asset in static.json (asset fingerprint manifest)')
     return `${path}/${asset}`
   }
-  return `${path}/${key}`
+  return `${path}/${isIndex ? '' : key}`
 }

--- a/test/unit/src/static/index-test.js
+++ b/test/unit/src/static/index-test.js
@@ -33,6 +33,15 @@ test('Local env returns non-fingerprinted path', t => {
   t.equal(asset, '/_static/foo.png', 'Returned non-fingerprinted path with stagePath option present')
 })
 
+test('Staging env returns _static path if root is requested', t => {
+  t.plan(1)
+  reset()
+  manifestExists = false
+  process.env.NODE_ENV = 'staging'
+  let asset = arcStatic('/')
+  t.equal(asset, '/_static/', 'Returned _static path')
+})
+
 test('Staging env returns non-fingerprinted path if static manifest is not present', t => {
   t.plan(1)
   reset()


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
