### PR TITLE
Fix and improve events.subscribe fallback object (handy for local tes…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Also see: [Architect changelog](https://github.com/architect/architect/blob/mast
 
 - Mocks API Gateway's current behavior of not sending a body when response is headers / status code only; fixes #254, /ht @alexbepple
   - (Back in the day it used to default to sending `\n` because reasons.)
+- Fixed and improved events.subscribe fallback object (handy for local testing)
 
 ---
 

--- a/src/events/subscribe.js
+++ b/src/events/subscribe.js
@@ -2,7 +2,7 @@ let parallel = require('run-parallel')
 
 let fallback = {
   Records: [
-    JSON.stringify({ Sns: { Message: {} } })
+    { Sns: { Message: JSON.stringify({}) } }
   ]
 }
 
@@ -21,7 +21,7 @@ let fallback = {
 module.exports = function _subscribe(fn) {
   if (fn.constructor.name === 'AsyncFunction') {
     return async function lambda(event) {
-      event = event || fallback
+      event = event && Object.keys(event).length ? event : fallback
       return await Promise.all(event.Records.map(async record=> {
         try {
           let result = JSON.parse(record.Sns.Message)
@@ -36,7 +36,7 @@ module.exports = function _subscribe(fn) {
   else {
     // callback interface
     return function _lambdaSignature(event, context, callback) {
-      event = event || fallback
+      event = event && Object.keys(event).length ? event : fallback
       // sns triggers send batches of records
       // so we're going to create a handler for each one
       // and execute them in parallel

--- a/test/unit/src/events/subscribe-test.js
+++ b/test/unit/src/events/subscribe-test.js
@@ -29,3 +29,25 @@ test('events.subscribe should invoke provided handler for each SNS event Record 
   t.ok(fake.calledWith({hey:"there"}), 'subscribe handler called with first SNS record')
   t.ok(fake.calledWith({sup:"bud"}), 'subscribe handler called with second SNS record')
 })
+
+test('events.subscribe should fall back to an empty event if one is not provided', t => {
+  t.plan(1)
+  let fake = sinon.fake.yields()
+  let handler = subscribe(fake)
+  handler(null, {}, function(err) {
+    if (err) t.fail(err)
+    else {
+      t.ok(fake.calledWith({}), 'subscribe handler called with empty SNS record')
+    }
+  })
+})
+
+test('events.subscribe should fall back to an empty event if one is not provided (async)', async t => {
+  t.plan(1)
+  let fake = sinon.fake()
+  let handler = subscribe(async function(json) {
+    fake(json)
+  })
+  await handler()
+  t.ok(fake.calledWith({}), 'subscribe handler called with empty SNS record')
+})


### PR DESCRIPTION
…ting)

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
