### PR TITLE
have `arc.http.helpers.url` respect ARC_LOCAL flag

### DIFF
--- a/src/http/helpers/url.js
+++ b/src/http/helpers/url.js
@@ -10,7 +10,7 @@
 module.exports = function url(url) {
   let staging = process.env.NODE_ENV === 'staging'
   let production = process.env.NODE_ENV === 'production'
-  if (staging || production)
+  if (!process.env.ARC_LOCAL && (staging || production))
     return `/${process.env.NODE_ENV}${url}`
   return url // fallthru for NODE_ENV=testing
 }

--- a/test/unit/src/http/helpers/url-test.js
+++ b/test/unit/src/http/helpers/url-test.js
@@ -1,0 +1,51 @@
+let test = require('tape')
+let url = require('../../../../../src/http/helpers/url')
+
+function reset () {
+  delete process.env.NODE_ENV
+  delete process.env.ARC_LOCAL
+  if (process.env.NODE_ENV) throw ReferenceError('NODE_ENV not unset')
+}
+
+test('Set up env', t => {
+  t.plan(1)
+  t.ok(url, 'url helper found')
+})
+
+test('Local (NODE_ENV=testing) env returns unmodified URL', t => {
+  t.plan(1)
+  reset()
+  process.env.NODE_ENV = 'testing'
+  let asset = url('foo.png')
+  t.equal(asset, 'foo.png', 'Returned unmodified path')
+})
+
+test('Staging env returns staging-prefixed URL', t => {
+  t.plan(1)
+  reset()
+  process.env.NODE_ENV = 'staging'
+  let asset = url('/')
+  t.equal(asset, '/staging/', 'Returned staging path')
+})
+
+test('Local env with staging mask (NODE_ENV=staging, ARC_LOCAL=1) returns unmodified path', t => {
+  t.plan(1)
+  reset()
+  process.env.NODE_ENV = 'staging'
+  process.env.ARC_LOCAL = '1'
+  let asset = url('bar.png')
+  t.equal(asset, 'bar.png', 'Returned staging path')
+})
+
+test('Production env returns production-prefixed URL', t => {
+  t.plan(1)
+  reset()
+  process.env.NODE_ENV = 'production'
+  let asset = url('/')
+  t.equal(asset, '/production/', 'Returned staging path')
+})
+
+test('Reset', t => {
+  reset()
+  t.end()
+})


### PR DESCRIPTION
this yields the same behaviour as `arc.static`. also added unit tests for http.helpers.url

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
