### PR TITLE
Fixed support for Lambda payload version 2 in session

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
 
+## vNext
+
+### Fixed
+- Support for Lambda payload version 2 in session
+
 ## [3.8.1] 2020-03-24
 
 ### Fixed

--- a/src/http/session/providers/ddb/index.js
+++ b/src/http/session/providers/ddb/index.js
@@ -28,7 +28,12 @@ function read(request, callback) {
   let secret = process.env.ARC_APP_SECRET || process.env.ARC_APP_NAME || 'fallback'
   // TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
   // lowercase 'cookie' on lambda...
-  let jar = cookie.parse(request.headers && request.headers.Cookie? request.headers.Cookie || '': '')
+  let rawCookie = request.headers && (request.headers.Cookie || request.headers.cookie)
+  // Lambda payload version 2 puts the cookies in an array on the request
+  if (!rawCookie && request.cookies) {
+    rawCookie = request.cookies.join(';')
+  }
+  let jar = cookie.parse(rawCookie || '')
   let sesh = jar.hasOwnProperty('_idx')
   let valid = unsign(jar._idx || '', secret)
 

--- a/src/http/session/providers/jwe.js
+++ b/src/http/session/providers/jwe.js
@@ -32,8 +32,14 @@ function read(req, callback) {
       }
     })
   }
-  let hasCookie = req.headers && (req.headers.Cookie || req.headers.cookie)
-  let jar = cookie.parse(hasCookie? (req.headers.Cookie || req.headers.cookie) : '')
+  // TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
+  // lowercase 'cookie' on lambda...
+  let rawCookie = req.headers && (req.headers.Cookie || req.headers.cookie)
+  // Lambda payload version 2 puts the cookies in an array on the request
+  if (!rawCookie && req.cookies) {
+    rawCookie = req.cookies.join(';')
+  }
+  let jar = cookie.parse(rawCookie || '')
   let token = jwe.parse(jar._idx)
   callback(null, token.valid? token.payload : {})
   return promise

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -11,7 +11,7 @@ test('http.session apis exist', t=> {
 })
 
 test('jwe read and write implementations', async t=> {
-  t.plan(4)
+  t.plan(5)
   process.env.SESSION_TABLE_NAME = 'jwe'
   process.env.SESSION_TTL = 14400
   let fakerequest = {}
@@ -25,6 +25,9 @@ test('jwe read and write implementations', async t=> {
   t.comment(JSON.stringify(cookie))
   t.comment(JSON.stringify(inception))
   t.ok(inception.one === 1, 'read back again')
+  // Lambda payload version 2
+  let inception2 = await read({cookies: [cookie]})
+  t.ok(inception2.one === 1, 'read back again from payload version 2')
   t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
@@ -37,7 +40,7 @@ test('set up sandbox for ddb testing', async t=> {
 })
 
 test('ddb read and write implementations', async t=> {
-  t.plan(4)
+  t.plan(5)
   process.env.SESSION_TABLE_NAME = 'arc-sessions'
   process.env.SESSION_TTL = 14400
   let fakerequest = {}
@@ -51,6 +54,9 @@ test('ddb read and write implementations', async t=> {
   t.comment(JSON.stringify(cookie))
   t.comment(JSON.stringify(inception))
   t.equals(inception.one, 1, 'read back modified cookie')
+  // Lambda payload version 2
+  let inception2 = await read({cookies: [cookie]})
+  t.ok(inception2.one === 1, 'read back again from payload version 2')
   t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 


### PR DESCRIPTION
In version 2, cookies are set in an array on request rather than a header. This change is backwards compatible with version 1.


## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
