### PR TITLE
Change reserved keyword variable name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 node_modules/
 test/mock/*/src/*/*/vendor/
 test/mock/project/src/
+yarn.lock

--- a/src/http/proxy/format/templatize.js
+++ b/src/http/proxy/format/templatize.js
@@ -8,10 +8,10 @@ module.exports = function templatizeResponse (params) {
   else {
     // Find: ${STATIC('path/filename.ext')}
     //   or: ${arc.static('path/filename.ext')}
-    let static = /\${(STATIC|arc\.static)\(.*\)}/g
+    let staticRegex = /\${(STATIC|arc\.static)\(.*\)}/g
     // Maybe stringify jic previous steps passed a buffer; perhaps we can remove this step if/when proxy plugins is retired
     let body = response.body instanceof Buffer ? Buffer.from(response.body).toString() : response.body
-    response.body = body.replace(static, function fingerprint(match) {
+    response.body = body.replace(staticRegex, function fingerprint(match) {
       let start = match.startsWith(`\${STATIC(`) ? 10 : 14
       let Key = match.slice(start, match.length-3)
       if (assets[Key] && !isLocal) {


### PR DESCRIPTION
Hello all,

I'm currently working on a small package that adds the ability to deploy ReasonML/Bucklescript projects to Begin.com via architect.

This requires "bundling" of sorts; nothing crazy, just bog-standard tree-shaking. I'm currently unable to do this effectively when using the functions package as `static` is a reserved word that's being used as a variable name in a file.

This PR solely renames that variable; all tests pass.