### PR TITLE
feat: Session cookie SameSite value is configurable with value in ARC…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
 
+## [3.13.10] 2021-01-18
+
+### Added
+
+- Session cookie's SameSite value is configurable with ARC_SESSION_SAME_SITE environment variable
+
 ## [3.13.9] 2021-01-13
 
 ### Added

--- a/src/http/session/providers/jwe.js
+++ b/src/http/session/providers/jwe.js
@@ -61,13 +61,14 @@ function write (payload, callback) {
   let key = '_idx'
   let val = jwe.create(payload)
   let maxAge = process.env.SESSION_TTL || 7.884e+8
+  let sameSite = process.env.ARC_SESSION_SAME_SITE || 'lax'
   let options = {
     maxAge,
     expires: new Date(Date.now() + maxAge * 1000),
     secure: true,
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite,
   }
   if (process.env.SESSION_DOMAIN) {
     options.domain = process.env.SESSION_DOMAIN

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -31,6 +31,21 @@ test('jwe read and write implementations', async t => {
   t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
+test('jwe SameSite is configurable', async t => {
+  t.plan(2)
+  process.env.SESSION_TABLE_NAME = 'jwe'
+  process.env.SESSION_TTL = 14400
+  let session = {}
+  // default value:
+  delete process.env.ARC_SESSION_SAME_SITE
+  let cookie = await write(session)
+  t.ok(cookie.includes(`SameSite=Lax`), 'cookie SameSite is set correctly to default')
+  // configured value:
+  process.env.ARC_SESSION_SAME_SITE = "None"
+  cookie = await write(session)
+  t.ok(cookie.includes(`SameSite=${process.env.ARC_SESSION_SAME_SITE}`), 'cookie SameSite is set correctly to configured value')
+})
+
 test('set up sandbox for ddb testing', t => {
   t.plan(1)
   process.chdir(join(process.cwd(), 'test', 'mock', 'project'))


### PR DESCRIPTION
This makes the session cookie's SameSite value is configurable with ARC_SESSION_SAME_SITE environment variable. If the variable doesn't exist, then it defaults to prior behavior (lax).

Related discussion at https://architecture-as-text.slack.com/archives/C6BGT0D08/p1610999938037300

NOTE: I see some failures when running `npm it` but they appear to be due to some AWS configuration that I need and couldn't track down.

Let me know which docs you think make sense to update and I can submit a PR for the other repo or update this one. I didn't see an obvious place. Maybe https://arc.codes/docs/en/reference/runtime/node#arc.http.session ?

----- 


- [+] Forked the repo and created your branch from `master`
- [+] Made sure tests pass (run `npm it` from the repo root)
- [+] Expanded test coverage related to your changes:
  - [+] Added and/or updated unit tests (if appropriate)
  - [+] Added and/or updated integration tests (if appropriate) _Didn't seem appropriate. Let me know if I missed something._
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [+] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
