### PR TITLE
sandbox _name() would sometimes return wrong table

### DIFF
--- a/src/tables/sandbox.js
+++ b/src/tables/sandbox.js
@@ -50,7 +50,7 @@ module.exports = function sandbox (callback) {
             }, {})
           }
 
-          let _name = name => tables.filter(t => RegExp(`^.*${name}$`).test(t))[0]
+          let _name = name => tables.filter(t => RegExp(`^.*-staging-${name}$`).test(t))[0]
           data.name = _name
           data._name = _name
 


### PR DESCRIPTION
The regex would match any table that had a name ending with the search string. For example with the tables `Users` and `CompanyUsers` a search for `Users` could return `CompanyUsers` instead if it's defined first.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ x [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
