### PR TITLE
docs: web socket documentation and jsdoc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,11 @@ Would yield the following objects:
 - `scan(params, callback)`: scans the table using `params` and invokes `callback` with the result
 - `update(params, callback)`: updates an item in the table using `params` and invokes `callback` when complete
 
+
+## `arc.ws.send({ id, payload })`
+
+Sends the object present on `payload` to the connection ID on `id`. Payload is passed to `JSON.stringify()` on your behalf. Uses [`postToConnection`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ApiGatewayManagementApi.html#postToConnection-property) from the `ApiGatewayManagementApi`. Returns a promise with no data on success.
+
 [npm]: https://www.npmjs.com/package/@architect/functions
 [sandbox]: https://www.npmjs.com/package/@architect/sandbox
 [events]: https://arc.codes/reference/events

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -8,7 +8,7 @@ let run = require('./send')
  *
  * @param {Object} params
  * @param {String} params.id - the ws connecton id (required)
- * @param {String} params.payload - a json event payload (required)
+ * @param {Object} params.payload - an event payload (required)
  * @param {Function} callback - a node style errback (optional)
  * @returns {Promise} - returned if no callback is supplied
  */


### PR DESCRIPTION
- You pass `send` an object not a string for payload
- Readme was missing info on this function

## Default stuff
- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes
