### PR TITLE
Fix `tables()` not returning a client wrapper for any tables with the word "production" in their names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,12 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
 
-## [3.13.10] 2021-01-18
+## [3.13.10] 2021-04-07
 
 ### Added
 
-- Session cookie's SameSite value is configurable with ARC_SESSION_SAME_SITE environment variable
+- Session cookie's SameSite value is configurable with ARC_SESSION_SAME_SITE environment variable; thanks @activescott!
+- Fixed issue with `arc.tables()` not generating a client for tables with the string `production` in their names in a Sandbox context
 
 ## [3.13.9] 2021-01-13
 

--- a/src/tables/sandbox.js
+++ b/src/tables/sandbox.js
@@ -19,7 +19,8 @@ module.exports = function sandbox (callback) {
         if (err) callback(err)
         else {
           let reduce = (a, b) => Object.assign({}, a, b)
-          let dontcare = tbl => tbl != 'arc-sessions' && tbl.includes('production') === false
+          // TODO: no such table name as 'arc-sessions' (they would all be in the form appname-env-tablename, so the below arc-sessions conditional is not providing value
+          let dontcare = tbl => tbl != 'arc-sessions' && tbl.includes('-production-') === false
           let tables = result.TableNames.filter(dontcare)
           let data = tables.map(function fmt (tbl) {
             let parts = tbl.split('-staging-')

--- a/test/unit/src/tables/sandbox-test.js
+++ b/test/unit/src/tables/sandbox-test.js
@@ -1,0 +1,43 @@
+let test = require('tape')
+let proxyquire = require('proxyquire')
+
+let fakeDoc = {}
+let fakeTables = { TableNames: [] }
+let fakeDb = { listTables: (_, cb) => cb(null, fakeTables) }
+const appname = 'testapp'
+function buildTables (arr) {
+  arr.push('arc-sessions')
+  let tables = []
+  arr.forEach(t => {
+    tables.push(`${appname}-staging-${t}`)
+    tables.push(`${appname}-production-${t}`)
+  })
+  return tables
+}
+
+let sandbox = proxyquire('../../../../src/tables/sandbox', {
+  './dynamo': { db: {}, doc: {} },
+  'run-parallel': (_, cb) => cb(null, [ fakeDb, fakeDoc ])
+})
+
+test('tables.sandbox should return a client/object with properties for each user-defined table', t => {
+  t.plan(4)
+  fakeTables.TableNames = buildTables([ 'accounts', 'posts' ])
+  sandbox((err, client) => {
+    if (err) t.fail(err)
+    t.ok(client._db === fakeDb, '_db property assigned')
+    t.ok(client._doc === fakeDoc, '_doc property assigned')
+    t.ok(client.accounts, 'first user-defined table created')
+    t.ok(client.posts, 'second user-defined table created')
+  })
+})
+
+test('tables.sandbox should return a client/object with properties for user-defined tables using arc reserved-ish names like staging and production', t => {
+  t.plan(2)
+  fakeTables.TableNames = buildTables([ 'stagings', 'productions' ])
+  sandbox((err, client) => {
+    if (err) t.fail(err)
+    t.ok(client.stagings, '"stagings" user-defined table created')
+    t.ok(client.productions, '"productions" user-defined table created')
+  })
+})


### PR DESCRIPTION
This fixes architect/architect#1111

Tho integration tests are disabled on this repo so I am wont to merge this 😞 