### PR TITLE
re-enable full test runs in ci, fix ddb-backed sessions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,7 @@ jobs:
       run: npm install
 
     - name: Test
-      # run: npm test
-      run: node test/unit/src/http/proxy/read/_local-test.js
+      run: npm test
       env:
         CI: true
 

--- a/src/http/session/providers/ddb/index.js
+++ b/src/http/session/providers/ddb/index.js
@@ -24,7 +24,7 @@ function read (request, callback) {
   }
 
   // read dynamo session table
-  let name = process.env.SESSION_TABLE_NAME || 'arc-sessions'
+  let name = process.env.SESSION_TABLE_NAME || tableLogicalId('arc-sessions')
   let secret = process.env.ARC_APP_SECRET || process.env.ARC_APP_NAME || 'fallback'
   // TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
   // lowercase 'cookie' on lambda...
@@ -52,7 +52,6 @@ function read (request, callback) {
  * - _secret
  */
 function write (params, callback) {
-
   // be async/await friendly
   let promise
   if (!callback) {
@@ -64,7 +63,7 @@ function write (params, callback) {
   }
 
   // read dynamo session table
-  let name = process.env.SESSION_TABLE_NAME || 'arc-sessions'
+  let name = process.env.SESSION_TABLE_NAME || tableLogicalId('arc-sessions')
   let secret = process.env.ARC_APP_SECRET || process.env.ARC_APP_NAME || 'fallback'
 
   update(name, params, function _update (err) {
@@ -92,4 +91,9 @@ function write (params, callback) {
   })
 
   return promise
+}
+
+function tableLogicalId (name) {
+  let env = process.env.NODE_ENV === 'production' ? 'production' : 'staging'
+  return `${process.env.ARC_APP_NAME}-${env}-${name}`
 }

--- a/test/integration/ddb-session-test.js
+++ b/test/integration/ddb-session-test.js
@@ -24,7 +24,7 @@ let origCwd = process.cwd()
 
 test('Set up env', async t => {
   t.plan(2)
-  process.env.SESSION_TABLE_NAME = 'arc-sessions'
+  process.env.SESSION_TABLE_NAME = 'test-only-staging-arc-sessions'
   process.chdir(mock)
   t.equal(process.cwd(), mock, 'Set working dir')
   let result = await sandbox.start({ quiet: true })

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -41,7 +41,7 @@ test('jwe SameSite is configurable', async t => {
   let cookie = await write(session)
   t.ok(cookie.includes(`SameSite=Lax`), 'cookie SameSite is set correctly to default')
   // configured value:
-  process.env.ARC_SESSION_SAME_SITE = "None"
+  process.env.ARC_SESSION_SAME_SITE = 'None'
   cookie = await write(session)
   t.ok(cookie.includes(`SameSite=${process.env.ARC_SESSION_SAME_SITE}`), 'cookie SameSite is set correctly to configured value')
 })


### PR DESCRIPTION
reading and writing ddb-backed sessions was a bit messed up, in a sandbox context we were using the wrong table names, need to be consistent in using logical ids for tables
