### PR TITLE
arc.services service map and new service discovery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/master/changelog.md)
 ---
 
+## [3.14.0] 2021-05-24
+
+### Added
+
+- New `arc.services()` API for retrieving the service map object for a given app; this object contains metadata associated with all infrastructure or services leveraged by the app
+
+---
+
 ## [3.13.12] 2021-05-24
 
 ### Changed
@@ -26,6 +34,8 @@ Also see: [Architect changelog](https://github.com/architect/architect/blob/mast
 
 - Session cookie's SameSite value is configurable with ARC_SESSION_SAME_SITE environment variable; thanks @activescott!
 - Fixed issue with `arc.tables()` not generating a client for tables with the string `production` in their names in a Sandbox context
+
+---
 
 ## [3.13.9] 2021-01-13
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "eslint --fix .",
     "test:unit": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/unit/**/*-test.js' | tap-spec",
-    "test:integration": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/integration/**/*-test.js' | tap-spec",
+    "test:integration": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/integration/ddb-session-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "test": "npm run lint && npm run test:integration && npm run coverage",
     "bundle": "echo 'For experimentation only, build from http-proxy!' && browserify src/http/proxy/arc-default-get-index.js --node --external aws-sdk --standalone proxy > dist.js",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/sandbox": "^3.1.3",
+    "@architect/sandbox": "^3.4.4-RC.0",
     "aws-sdk": "2.799.0",
     "aws-sdk-mock": "^5.1.0",
     "browserify": "^16.5.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/sandbox": "^3.4.4-RC.0",
+    "@architect/sandbox": "^3.4.4-RC.1",
     "aws-sdk": "2.799.0",
     "aws-sdk-mock": "^5.1.0",
     "browserify": "^16.5.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/sandbox": "^3.4.4-RC.1",
+    "@architect/sandbox": "^3.6.0",
     "aws-sdk": "2.799.0",
     "aws-sdk-mock": "^5.1.0",
     "browserify": "^16.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "eslint --fix .",
     "test:unit": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/unit/**/*-test.js' | tap-spec",
-    "test:integration": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/integration/ddb-session-test.js' | tap-spec",
+    "test:integration": "cross-env PORT=6666 NODE_ENV=testing AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_REGION=us-west-1 tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "test": "npm run lint && npm run test:integration && npm run coverage",
     "bundle": "echo 'For experimentation only, build from http-proxy!' && browserify src/http/proxy/arc-default-get-index.js --node --external aws-sdk --standalone proxy > dist.js",
@@ -52,6 +52,7 @@
     "@architect/eslint-config": "1.0.0",
     "@architect/sandbox": "^3.1.3",
     "aws-sdk": "2.799.0",
+    "aws-sdk-mock": "^5.1.0",
     "browserify": "^16.5.2",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.2",

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -4,6 +4,33 @@ let aws = require('aws-sdk')
  * @returns {object} {name: value}
  */
 module.exports = function lookup (callback) {
+  if (process.env.NODE_ENV === 'testing') lookupSandbox(callback)
+  else lookupSSM(callback)
+}
+
+function lookupSandbox (callback) {
+  let port = process.env.PORT || 3333
+  let req = http.request({
+    method: 'GET',
+    port,
+    path: '/_asd',
+  },
+  function done (res) {
+    let data = []
+    res.resume()
+    res.on('data', chunk => data.push(chunk))
+    res.on('end', () => {
+      let body = Buffer.concat(data).toString()
+      let code = `${res.statusCode}`
+      if (!code.startsWith(2)) callback(Error(`_asd error; (${code}) ${body}`))
+      else callback(null, JSON.parse(body))
+    })
+  })
+  req.write(JSON.stringify(params))
+  req.end('\n')
+}
+
+function lookupSSM (callback) {
   let st = new Date().valueOf()
   let Path = `/${process.env.ARC_CLOUDFORMATION}`
   let Recursive = true

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -1,41 +1,47 @@
 let aws = require('aws-sdk')
-
 /**
  * @param {string} type - events, queues, or tables
  * @returns {object} {name: value}
  */
-function lookup (type, callback) {
-
+module.exports = function lookup (callback) {
+  let st = new Date().valueOf()
   let Path = `/${process.env.ARC_CLOUDFORMATION}`
   let Recursive = true
   let values = []
 
   function getParams (params) {
-    let isType = p => p.Name.split('/')[2] === type
     let ssm = new aws.SSM
     ssm.getParametersByPath(params, function done (err, result) {
       if (err) {
         callback(err)
       }
       else if (result.NextToken) {
-        values = values.concat(result.Parameters.filter(isType))
+        values = values.concat(result.Parameters)
         getParams({ Path, Recursive, NextToken: result.NextToken })
       }
       else {
-        values = values.concat(result.Parameters.filter(isType))
+        values = values.concat(result.Parameters)
         callback(null, values.reduce((a, b) => {
-          a[b.Name.split('/')[3]] = b.Value
+          let hierarchy = b.Name.split('/')
+          hierarchy.shift() // leading slash
+          hierarchy.shift() // stack name
+          let type = hierarchy.shift() // i.e. tables, events, queues, plugins
+          if (!a[type]) a[type] = {}
+          let parent = a[type]
+          let child, lastChild, lastParent
+          while (child = hierarchy.shift()) {
+            parent[child] = {}
+            lastParent = parent
+            parent = parent[child]
+            lastChild = child
+          }
+          lastParent[lastChild] = b.Value
           return a
         }, {}))
+        console.log('discovery took', (new Date().valueOf() - st), 'ms')
       }
     })
   }
 
   getParams({ Path, Recursive })
-}
-
-module.exports = {
-  events: lookup.bind({}, 'events'),
-  queues: lookup.bind({}, 'queues'),
-  tables: lookup.bind({}, 'tables')
 }

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -43,7 +43,7 @@ module.exports = function lookup (callback) {
           let child, lastChild, lastParent
           /* eslint-disable-next-line */
           while (child = hierarchy.shift()) {
-            parent[child] = {}
+            if (!parent[child]) parent[child] = {}
             lastParent = parent
             parent = parent[child]
             lastChild = child

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -1,4 +1,5 @@
 let aws = require('aws-sdk')
+let http = require('http')
 /**
  * @param {string} type - events, queues, or tables
  * @returns {object} {name: value}
@@ -26,12 +27,10 @@ function lookupSandbox (callback) {
       else callback(null, JSON.parse(body))
     })
   })
-  req.write(JSON.stringify(params))
   req.end('\n')
 }
 
 function lookupSSM (callback) {
-  let st = new Date().valueOf()
   let Path = `/${process.env.ARC_CLOUDFORMATION}`
   let Recursive = true
   let values = []
@@ -56,6 +55,7 @@ function lookupSSM (callback) {
           if (!a[type]) a[type] = {}
           let parent = a[type]
           let child, lastChild, lastParent
+          /* eslint-disable-next-line */
           while (child = hierarchy.shift()) {
             parent[child] = {}
             lastParent = parent
@@ -65,7 +65,6 @@ function lookupSSM (callback) {
           lastParent[lastChild] = b.Value
           return a
         }, {}))
-        console.log('discovery took', (new Date().valueOf() - st), 'ms')
       }
     })
   }

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -5,38 +5,24 @@ let http = require('http')
  * @returns {object} {name: value}
  */
 module.exports = function lookup (callback) {
-  if (process.env.NODE_ENV === 'testing') lookupSandbox(callback)
-  else lookupSSM(callback)
-}
-
-function lookupSandbox (callback) {
-  let port = process.env.PORT || 3333
-  let req = http.request({
-    method: 'GET',
-    port,
-    path: '/_asd',
-  },
-  function done (res) {
-    let data = []
-    res.resume()
-    res.on('data', chunk => data.push(chunk))
-    res.on('end', () => {
-      let body = Buffer.concat(data).toString()
-      let code = `${res.statusCode}`
-      if (!code.startsWith(2)) callback(Error(`_asd error; (${code}) ${body}`))
-      else callback(null, JSON.parse(body))
-    })
-  })
-  req.end('\n')
-}
-
-function lookupSSM (callback) {
   let Path = `/${process.env.ARC_CLOUDFORMATION}`
   let Recursive = true
   let values = []
+  let isLocal = process.env.NODE_ENV === 'testing'
+  let config
+  if (isLocal) {
+    // if running in sandbox, sandbox has an SSM mock, use that
+    let port = process.env.ARC_INTERNAL || 3332
+    let region = process.env.AWS_REGION || 'us-west-2'
+    config = {
+      endpoint: new aws.Endpoint(`http://localhost:${port}/_arc/ssm`),
+      region,
+      httpOptions: { agent: new http.Agent() }
+    }
+  }
+  let ssm = new aws.SSM(config)
 
   function getParams (params) {
-    let ssm = new aws.SSM
     ssm.getParametersByPath(params, function done (err, result) {
       if (err) {
         callback(err)

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,36 +1,37 @@
 let oldPublish = require('./publish-old')
-let publish = require('./publish')
 let subscribe = require('./subscribe')
 
-module.exports = {
+module.exports = function eventFactory (services) {
+  let publish = require('./publish')(services)
+  return {
+    /**
+     * arc.events.publish
+     *
+     * publish events (sns topics)
+     *
+     * @param {Object} params
+     * @param {String} params.name - the event name (required)
+     * @param {String} params.payload - a json event payload (required)
+     * @param {Function} callback - a node style errback (optional)
+     * @returns {Promise} - returned if no callback is supplied
+     */
+    publish (params, callback) {
+      if (process.env.ARC_CLOUDFORMATION) {
+        return publish(params, callback)
+      }
+      else {
+        return oldPublish(params, callback)
+      }
+    },
 
-  /**
-   * arc.events.publish
-   *
-   * publish events (sns topics)
-   *
-   * @param {Object} params
-   * @param {String} params.name - the event name (required)
-   * @param {String} params.payload - a json event payload (required)
-   * @param {Function} callback - a node style errback (optional)
-   * @returns {Promise} - returned if no callback is supplied
-   */
-  publish (params, callback) {
-    if (process.env.ARC_CLOUDFORMATION) {
-      return publish(params, callback)
-    }
-    else {
-      return oldPublish(params, callback)
-    }
-  },
-
-  /**
-   * arc.events.subscribe
-   *
-   * listen for events (sns topics)
-   *
-   * @param {Function} handler - a single event handler function
-   * @returns {Lambda} - a Lambda function sig: (event, context, callback)=>
-   */
-  subscribe,
+    /**
+     * arc.events.subscribe
+     *
+     * listen for events (sns topics)
+     *
+     * @param {Function} handler - a single event handler function
+     * @returns {Lambda} - a Lambda function sig: (event, context, callback)=>
+     */
+    subscribe
+  }
 }

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,8 +1,9 @@
 let oldPublish = require('./publish-old')
 let subscribe = require('./subscribe')
+let publishFactory = require('./publish')
 
-module.exports = function eventFactory (services) {
-  let publish = require('./publish')(services)
+module.exports = function eventFactory (arc) {
+  let publish = publishFactory(arc)
   return {
     /**
      * arc.events.publish

--- a/src/events/publish-topic.js
+++ b/src/events/publish-topic.js
@@ -22,14 +22,8 @@ module.exports = function liveFactory (arc) {
     if (arn) {
       publish(ledger[name], payload, callback)
     }
-    else if (!arc.services) {
-      // lazy load service map if not fetched yet
-      console.log('lazy loading events')
-      arc._loadServices().then(cacheLedgerAndPublish).catch(callback)
-    }
     else {
-      // services were loaded before, set up queue ledger / cache
-      cacheLedgerAndPublish(arc.services)
+      arc.services().then(cacheLedgerAndPublish).catch(callback)
     }
   }
 }

--- a/src/events/publish-topic.js
+++ b/src/events/publish-topic.js
@@ -1,31 +1,29 @@
 let aws = require('aws-sdk')
-let lookup = require('../discovery')
 let ledger = {}
 
-module.exports = function live ({ name, payload }, callback) {
+module.exports = function liveFactory (services) {
+  return function live ({ name, payload }, callback) {
 
-  function publish (arn, payload, callback) {
-    let sns = new aws.SNS
-    sns.publish({
-      TopicArn: arn,
-      Message: JSON.stringify(payload)
-    }, callback)
-  }
+    function publish (arn, payload, callback) {
+      let sns = new aws.SNS
+      sns.publish({
+        TopicArn: arn,
+        Message: JSON.stringify(payload)
+      }, callback)
+    }
 
-  let arn = ledger[name]
-  if (arn) {
-    publish(ledger[name], payload, callback)
-  }
-  else {
-    lookup.events(function done (err, found) {
-      if (err) callback(err)
-      else if (!found[name]) {
-        callback(ReferenceError(`${name} not found`))
-      }
-      else {
-        ledger = found
-        publish(ledger[name], payload, callback)
-      }
-    })
+    let arn = ledger[name]
+    if (arn) {
+      publish(ledger[name], payload, callback)
+    }
+    else {
+      services.then(function (serviceMap) {
+        if (!serviceMap.events[name]) callback(ReferenceError(`${name} event not found`))
+        else {
+          ledger = serviceMap.events
+          publish(ledger[name], payload, callback)
+        }
+      }).catch(callback)
+    }
   }
 }

--- a/src/events/publish-topic.js
+++ b/src/events/publish-topic.js
@@ -28,7 +28,7 @@ module.exports = function liveFactory (arc) {
       arc._loadServices().then(cacheLedgerAndPublish).catch(callback)
     }
     else {
-      // services were loaded before, set up queue ledger / cache 
+      // services were loaded before, set up queue ledger / cache
       cacheLedgerAndPublish(arc.services)
     }
   }

--- a/src/events/publish-topic.js
+++ b/src/events/publish-topic.js
@@ -1,7 +1,7 @@
 let aws = require('aws-sdk')
 let ledger = {}
 
-module.exports = function liveFactory (services) {
+module.exports = function liveFactory (arc) {
   return function live ({ name, payload }, callback) {
 
     function publish (arn, payload, callback) {
@@ -12,18 +12,24 @@ module.exports = function liveFactory (services) {
       }, callback)
     }
 
+    function cacheLedgerAndPublish (serviceMap) {
+      ledger = serviceMap.events
+      if (!ledger[name]) callback(ReferenceError(`${name} event not found`))
+      else publish(ledger[name], payload, callback)
+    }
+
     let arn = ledger[name]
     if (arn) {
       publish(ledger[name], payload, callback)
     }
+    else if (!arc.services) {
+      // lazy load service map if not fetched yet
+      console.log('lazy loading events')
+      arc._loadServices().then(cacheLedgerAndPublish).catch(callback)
+    }
     else {
-      services.then(function (serviceMap) {
-        if (!serviceMap.events[name]) callback(ReferenceError(`${name} event not found`))
-        else {
-          ledger = serviceMap.events
-          publish(ledger[name], payload, callback)
-        }
-      }).catch(callback)
+      // services were loaded before, set up queue ledger / cache 
+      cacheLedgerAndPublish(arc.services)
     }
   }
 }

--- a/src/events/publish.js
+++ b/src/events/publish.js
@@ -1,28 +1,29 @@
 let sandbox = require('./publish-sandbox')
-let topic = require('./publish-topic')
 
 /**
  * invoke an event lambda by sns topic name
  */
-module.exports = function publish (params, callback) {
+module.exports = function publishFactory (services) {
+  let topic = require('./publish-topic')(services)
+  return function publish (params, callback) {
+    if (!params.name)
+      throw ReferenceError('missing params.name')
 
-  if (!params.name)
-    throw ReferenceError('missing params.name')
+    if (!params.payload)
+      throw ReferenceError('missing params.payload')
 
-  if (!params.payload)
-    throw ReferenceError('missing params.payload')
+    let promise
+    if (!callback) {
+      promise = new Promise((resolve, reject) => {
+        callback = function errback (err, result) {
+          err ? reject(err) : resolve(result)
+        }
+      })
+    }
 
-  let promise
-  if (!callback) {
-    promise = new Promise((resolve, reject) => {
-      callback = function errback (err, result) {
-        err ? reject(err) : resolve(result)
-      }
-    })
+    let isLocal = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
+    let exec = isLocal ? sandbox : topic
+    exec(params, callback)
+    return promise
   }
-
-  let isLocal = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
-  let exec = isLocal ? sandbox : topic
-  exec(params, callback)
-  return promise
 }

--- a/src/events/publish.js
+++ b/src/events/publish.js
@@ -1,10 +1,11 @@
 let sandbox = require('./publish-sandbox')
+let topicFactory = require('./publish-topic')
 
 /**
  * invoke an event lambda by sns topic name
  */
-module.exports = function publishFactory (services) {
-  let topic = require('./publish-topic')(services)
+module.exports = function publishFactory (arc) {
+  let topic = topicFactory(arc)
   return function publish (params, callback) {
     if (!params.name)
       throw ReferenceError('missing params.name')

--- a/src/index.js
+++ b/src/index.js
@@ -13,21 +13,21 @@ if (!env || isNotStagingOrProd) {
 let http = require('./http')
 let _static = require('./static')
 let serviceDiscovery = require('./discovery')
-/*
-*/
+let services
+
 let send = require('./ws')
 let arc = {
   http,
   static: _static,
   ws: { send },
-  services: false,
-  _loadServices: function () {
+  services: function () {
     return new Promise(function (resolve, reject) {
-      serviceDiscovery(function (err, serviceMap) {
+      if (services) resolve(services)
+      else serviceDiscovery(function (err, serviceMap) {
         if (err) reject(err)
         else {
-          arc.services = serviceMap
-          resolve(arc.services)
+          services = serviceMap
+          resolve(services)
         }
       })
     })

--- a/src/index.js
+++ b/src/index.js
@@ -9,21 +9,27 @@ if (!env || isNotStagingOrProd) {
   process.env.NODE_ENV = 'testing'
 }
 
-let events = require('./events')
-let http = require('./http')
-let queues = require('./queues')
-let _static = require('./static')
-let tables = require('./tables')
-let send = require('./ws')
 
+let http = require('./http')
+let _static = require('./static')
+let serviceDiscovery = require('./discovery')
+/*
+*/
+let send = require('./ws')
 let arc = {
-  events,
   http,
-  queues,
   static: _static,
-  tables,
   ws: { send },
+  services: new Promise(function (resolve, reject) {
+    serviceDiscovery(function (err, serviceMap) {
+      if (err) reject(err)
+      else resolve(serviceMap)
+    })
+  }),
 }
+arc.tables = require('./tables')(arc.services)
+arc.queues = require('./queues')(arc.services)
+arc.events = require('./events')(arc.services)
 
 // backwards compat
 arc.proxy = {}

--- a/src/index.js
+++ b/src/index.js
@@ -20,16 +20,22 @@ let arc = {
   http,
   static: _static,
   ws: { send },
-  services: new Promise(function (resolve, reject) {
-    serviceDiscovery(function (err, serviceMap) {
-      if (err) reject(err)
-      else resolve(serviceMap)
+  services: false,
+  _loadServices: function () {
+    return new Promise(function (resolve, reject) {
+      serviceDiscovery(function (err, serviceMap) {
+        if (err) reject(err)
+        else {
+          arc.services = serviceMap
+          resolve(arc.services)
+        }
+      })
     })
-  }),
+  }
 }
-arc.tables = require('./tables')(arc.services)
-arc.queues = require('./queues')(arc.services)
-arc.events = require('./events')(arc.services)
+arc.tables = require('./tables')(arc)
+arc.queues = require('./queues')(arc)
+arc.events = require('./events')(arc)
 
 // backwards compat
 arc.proxy = {}

--- a/src/queues/index.js
+++ b/src/queues/index.js
@@ -1,36 +1,37 @@
 let oldPublish = require('./publish-old')
-let publish = require('./publish')
 let subscribe = require('./subscribe')
 
-module.exports = {
+module.exports = function queueFactory (services) {
+  let publish = require('./publish')(services)
+  return {
+    /**
+     * arc.queues.publish
+     *
+     * publish to an sqs queue
+     *
+     * @param {Object} params
+     * @param {String} params.name - the queue name (required)
+     * @param {String} params.payload - a json event payload (required)
+     * @param {Function} callback - a node style errback (optional)
+     * @returns {Promise} - returned if no callback is supplied
+     */
+    publish (params, callback) {
+      if (process.env.ARC_CLOUDFORMATION) {
+        return publish(params, callback)
+      }
+      else {
+        return oldPublish(params, callback)
+      }
+    },
 
-  /**
-   * arc.queues.publish
-   *
-   * publish to an sqs queue
-   *
-   * @param {Object} params
-   * @param {String} params.name - the queue name (required)
-   * @param {String} params.payload - a json event payload (required)
-   * @param {Function} callback - a node style errback (optional)
-   * @returns {Promise} - returned if no callback is supplied
-   */
-  publish (params, callback) {
-    if (process.env.ARC_CLOUDFORMATION) {
-      return publish(params, callback)
-    }
-    else {
-      return oldPublish(params, callback)
-    }
-  },
-
-  /**
-   * arc.queues.subscribe
-   *
-   * handle payloads published to the queue
-   *
-   * @param {Function} handler - a single queue handler function
-   * @returns {Lambda} - a Lambda function sig: (event, context, callback)=>
-   */
-  subscribe,
+    /**
+     * arc.queues.subscribe
+     *
+     * handle payloads published to the queue
+     *
+     * @param {Function} handler - a single queue handler function
+     * @returns {Lambda} - a Lambda function sig: (event, context, callback)=>
+     */
+    subscribe,
+  }
 }

--- a/src/queues/index.js
+++ b/src/queues/index.js
@@ -1,8 +1,9 @@
 let oldPublish = require('./publish-old')
 let subscribe = require('./subscribe')
+let publishFactory = require('./publish')
 
-module.exports = function queueFactory (services) {
-  let publish = require('./publish')(services)
+module.exports = function queueFactory (arc) {
+  let publish = publishFactory(arc)
   return {
     /**
      * arc.queues.publish

--- a/src/queues/publish-queue.js
+++ b/src/queues/publish-queue.js
@@ -27,14 +27,8 @@ module.exports = function liveFactory (arc) {
     if (arn) {
       publish(ledger[name], payload, callback)
     }
-    else if (!arc.services) {
-      // lazy load service map if not fetched yet
-      console.log('lazy loading queues')
-      arc._loadServices().then(cacheLedgerAndPublish).catch(callback)
-    }
     else {
-      // services were loaded before, set up queue ledger / cache
-      cacheLedgerAndPublish(arc.services)
+      arc.services().then(cacheLedgerAndPublish).catch(callback)
     }
   }
 }

--- a/src/queues/publish-queue.js
+++ b/src/queues/publish-queue.js
@@ -33,7 +33,7 @@ module.exports = function liveFactory (arc) {
       arc._loadServices().then(cacheLedgerAndPublish).catch(callback)
     }
     else {
-      // services were loaded before, set up queue ledger / cache 
+      // services were loaded before, set up queue ledger / cache
       cacheLedgerAndPublish(arc.services)
     }
   }

--- a/src/queues/publish.js
+++ b/src/queues/publish.js
@@ -1,28 +1,30 @@
 let sandbox = require('./publish-sandbox')
-let queue = require('./publish-queue')
 
 /**
  * invoke a queue lambda by sqs queue name
  */
-module.exports = function publish (params, callback) {
+module.exports = function publishFactory (services) {
+  let queue = require('./publish-queue')(services)
+  return function publish (params, callback) {
 
-  if (!params.name)
-    throw ReferenceError('missing params.name')
+    if (!params.name)
+      throw ReferenceError('missing params.name')
 
-  if (!params.payload)
-    throw ReferenceError('missing params.payload')
+    if (!params.payload)
+      throw ReferenceError('missing params.payload')
 
-  let promise
-  if (!callback) {
-    promise = new Promise((resolve, reject) => {
-      callback = function errback (err, result) {
-        err ? reject(err) : resolve(result)
-      }
-    })
+    let promise
+    if (!callback) {
+      promise = new Promise((resolve, reject) => {
+        callback = function errback (err, result) {
+          err ? reject(err) : resolve(result)
+        }
+      })
+    }
+
+    let isLocal = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
+    let exec = isLocal ? sandbox : queue
+    exec(params, callback)
+    return promise
   }
-
-  let isLocal = process.env.NODE_ENV === 'testing' || process.env.ARC_LOCAL
-  let exec = isLocal ? sandbox : queue
-  exec(params, callback)
-  return promise
 }

--- a/src/queues/publish.js
+++ b/src/queues/publish.js
@@ -1,10 +1,11 @@
 let sandbox = require('./publish-sandbox')
+let queueFactory = require('./publish-queue')
 
 /**
  * invoke a queue lambda by sqs queue name
  */
-module.exports = function publishFactory (services) {
-  let queue = require('./publish-queue')(services)
+module.exports = function publishFactory (arc) {
+  let queue = queueFactory(arc)
   return function publish (params, callback) {
 
     if (!params.name)

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -18,7 +18,7 @@ let client = false
  *  return {statusCode: 200}
  * }
  */
-function tables (services) {
+function tables (arc) {
   let api = function (callback) {
     let promise
     if (!callback) {
@@ -42,10 +42,14 @@ function tables (services) {
     else {
       waterfall([
         function (callback) {
-          services.then(function (serviceMap) {
-            console.log('tables instantiation, service map returned', serviceMap)
-            callback(null, serviceMap.tables)
-          }).catch(callback)
+          // lazy load service map if not fetched yet
+          if (!arc.services) {
+            console.log('lazy loading tables')
+            arc._loadServices().then(function (serviceMap) {
+              callback(null, serviceMap.tables)
+            }).catch(callback)
+          }
+          else callback(arc.services.tables)
         },
         factory,
         function (created, callback) {
@@ -69,9 +73,7 @@ function tables (services) {
   api.all = old.all
   api.save = old.save
   api.change = old.change
-  api() // kick off fetching and caching the table client pre-emptively
   return api
 }
-
 
 module.exports = tables

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -48,7 +48,7 @@ function tables (arc) {
               callback(null, serviceMap.tables)
             }).catch(callback)
           }
-          else callback(arc.services.tables)
+          else callback(null, arc.services.tables)
         },
         factory,
         function (created, callback) {

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -41,14 +41,9 @@ function tables (arc) {
     else {
       waterfall([
         function (callback) {
-          // lazy load service map if not fetched yet
-          if (!arc.services) {
-            console.log('lazy loading tables')
-            arc._loadServices().then(function (serviceMap) {
-              callback(null, serviceMap.tables)
-            }).catch(callback)
-          }
-          else callback(null, arc.services.tables)
+          arc.services().then(function (serviceMap) {
+            callback(null, serviceMap.tables)
+          }).catch(callback)
         },
         factory,
         function (created, callback) {

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -18,51 +18,60 @@ let client = false
  *  return {statusCode: 200}
  * }
  */
-function tables (callback) {
-  let promise
-  if (!callback) {
-    promise = new Promise(function ugh (res, rej) {
-      callback = function errback (err, result) {
-        if (err) rej(err)
-        else res(result)
-      }
-    })
+function tables (services) {
+  let api = function (callback) {
+    let promise
+    if (!callback) {
+      promise = new Promise(function ugh (res, rej) {
+        callback = function errback (err, result) {
+          if (err) rej(err)
+          else res(result)
+        }
+      })
+    }
+    /**
+     * Read Architect manifest if local / sandbox, otherwise use service reflection
+     */
+    let runningLocally = process.env.NODE_ENV === 'testing'
+    if (runningLocally) {
+      sandbox(callback)
+    }
+    else if (client) {
+      callback(null, client)
+    }
+    else {
+      waterfall([
+        function (callback) {
+          services.then(function (serviceMap) {
+            console.log('tables instantiation, service map returned', serviceMap)
+            callback(null, serviceMap.tables)
+          }).catch(callback)
+        },
+        factory,
+        function (created, callback) {
+          client = created
+          callback(null, client)
+        }
+      ], callback)
+    }
+    return promise
   }
-  /**
-   * Read Architect manifest if local / sandbox, otherwise use service reflection
-   */
-  let runningLocally = process.env.NODE_ENV === 'testing'
-  if (runningLocally) {
-    sandbox(callback)
-  }
-  else if (client) {
-    callback(null, client)
-  }
-  else {
-    waterfall([
-      lookup.tables,
-      factory,
-      function (created, callback) {
-        client = created
-        callback(null, client)
-      }
-    ], callback)
-  }
-  return promise
+  // Export directly for fast use
+  api.doc = dynamo.direct.doc
+  api.db = dynamo.direct.db
+
+  // Legacy compat methods
+  api.insert = old.insert
+  api.modify = old.modify
+  api.update = old.update
+  api.remove = old.remove
+  api.destroy = old.destroy
+  api.all = old.all
+  api.save = old.save
+  api.change = old.change
+  api() // kick off fetching and caching the table client pre-emptively
+  return api
 }
 
-// Export directly for fast use
-tables.doc = dynamo.direct.doc
-tables.db = dynamo.direct.db
-
-// Legacy compat methods
-tables.insert = old.insert
-tables.modify = old.modify
-tables.update = old.update
-tables.remove = old.remove
-tables.destroy = old.destroy
-tables.all = old.all
-tables.save = old.save
-tables.change = old.change
 
 module.exports = tables

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -1,6 +1,5 @@
 let waterfall = require('run-waterfall')
 let old = require('./old')
-let lookup = require('../discovery')
 let factory = require('./factory')
 let sandbox = require('./sandbox')
 let dynamo = require('./dynamo')
@@ -19,7 +18,7 @@ let client = false
  * }
  */
 function tables (arc) {
-  let api = function (callback) {
+  function api (callback) {
     let promise
     if (!callback) {
       promise = new Promise(function ugh (res, rej) {

--- a/test/integration/ddb-session-test.js
+++ b/test/integration/ddb-session-test.js
@@ -27,14 +27,13 @@ test('Set up env', async t => {
   process.env.SESSION_TABLE_NAME = 'test-only-staging-arc-sessions'
   process.chdir(mock)
   t.equal(process.cwd(), mock, 'Set working dir')
-  let result = await sandbox.start()
+  let result = await sandbox.start({ quiet: true })
   t.equal(result, 'Sandbox successfully started', result)
 })
 
 test('Create an initial session', async t => {
   t.plan(1)
   let dest = url('/http-session')
-  console.log('going to', dest)
   let result = await tiny.get({ url: dest })
   cookie = result.headers['set-cookie'][0]
   t.ok(cookie, `Got cookie to use in sessions: ${cookie.substr(0, 50)}...`)

--- a/test/integration/ddb-session-test.js
+++ b/test/integration/ddb-session-test.js
@@ -27,13 +27,15 @@ test('Set up env', async t => {
   process.env.SESSION_TABLE_NAME = 'test-only-staging-arc-sessions'
   process.chdir(mock)
   t.equal(process.cwd(), mock, 'Set working dir')
-  let result = await sandbox.start({ quiet: true })
+  let result = await sandbox.start()
   t.equal(result, 'Sandbox successfully started', result)
 })
 
 test('Create an initial session', async t => {
   t.plan(1)
-  let result = await tiny.get({ url: url('/http-session') })
+  let dest = url('/http-session')
+  console.log('going to', dest)
+  let result = await tiny.get({ url: dest })
   cookie = result.headers['set-cookie'][0]
   t.ok(cookie, `Got cookie to use in sessions: ${cookie.substr(0, 50)}...`)
 })

--- a/test/unit/src/discovery/index-test.js
+++ b/test/unit/src/discovery/index-test.js
@@ -1,0 +1,59 @@
+let test = require('tape')
+let aws = require('aws-sdk-mock')
+let discovery = require('../../../../src/discovery')
+
+test('discovery should callback with error if SSM errors', t => {
+  t.plan(1)
+  aws.mock('SSM', 'getParametersByPath', (params, cb) => cb(true))
+  discovery(err => {
+    t.ok(err, 'error passed into discovery callback')
+    aws.restore()
+  })
+})
+
+test('discovery should parse hierarchical SSM parameters into a service map object', t => {
+  t.plan(3)
+  aws.mock('SSM', 'getParametersByPath', (params, cb) => cb(null, {
+    Parameters: [
+      { Name: '/app/tables/cats', Value: 'tableofcats' },
+      { Name: '/app/events/walkthedog', Value: 'timetowalkthedog' }
+    ]
+  }))
+  discovery((err, services) => {
+    t.notOk(err, 'no error passed to callback')
+    t.equals(services.tables.cats, 'tableofcats', 'cat table value set up in correct place of service map')
+    t.equals(services.events.walkthedog, 'timetowalkthedog', 'dogwalking event value set up in correct place of service map')
+    aws.restore()
+  })
+})
+
+test('discovery should parse several pages of hierarchical SSM parameters into a service map object', t => {
+  t.plan(5)
+  let ssmCounter = 0
+  aws.mock('SSM', 'getParametersByPath', (params, cb) => {
+    let NextToken = null
+    let Parameters = [
+      { Name: '/app/tables/cats', Value: 'tableofcats' },
+      { Name: '/app/events/walkthedog', Value: 'timetowalkthedog' }
+    ]
+    if (ssmCounter === 1) {
+      Parameters[0].Name = '/app/queues/breadline'
+      Parameters[0].Value = 'favouritebakery'
+      Parameters[1].Name = '/app/tables/ofcontents'
+      Parameters[1].Value = 'chapters'
+    }
+    else {
+      NextToken = 'yes'
+    }
+    ssmCounter++
+    cb(null, { NextToken, Parameters })
+  })
+  discovery((err, services) => {
+    t.notOk(err, 'no error passed to callback')
+    t.equals(services.tables.cats, 'tableofcats', 'cat table value set up in correct place of service map')
+    t.equals(services.events.walkthedog, 'timetowalkthedog', 'dogwalking event value set up in correct place of service map')
+    t.equals(services.tables.ofcontents, 'chapters', 'ofcontents table value set up in correct place of service map')
+    t.equals(services.queues.breadline, 'favouritebakery', 'breadline queue value set up in correct place of service map')
+    aws.restore()
+  })
+})

--- a/test/unit/src/events/publish-test.js
+++ b/test/unit/src/events/publish-test.js
@@ -1,5 +1,6 @@
 let test = require('tape')
-let publish = require('../../../../src/events/publish')
+let arc = require('../../../..')
+let publish = require('../../../../src/events/publish')(arc)
 
 test('events.publish should throw if there is no parameter name', t => {
   t.plan(1)

--- a/test/unit/src/queues/publish-test.js
+++ b/test/unit/src/queues/publish-test.js
@@ -1,5 +1,6 @@
 let test = require('tape')
-let publish = require('../../../../src/queues/publish')
+let arc = require('../../../../')
+let publish = require('../../../../src/queues/publish')(arc)
 
 test('queues.publish should throw if there is no parameter name', t => {
   t.plan(1)


### PR DESCRIPTION
This relates to the work described in the service discovery thread: https://github.com/architect/architect/issues/1091

The local-service-discovery component requires use in conjunction with this open sandbox pull request: https://github.com/architect/sandbox/pull/563/

I think I'd like to test this out all packaged together with a few other moving parts (`deploy`, `sandbox` and the docs) in a new minor version (RC release to start with) of architect.