### PR TITLE
use `match` and `equals` instead of `ok` where possible in tape tests

### DIFF
--- a/test/unit/src/http/async/index-res-test.js
+++ b/test/unit/src/http/async/index-res-test.js
@@ -51,75 +51,75 @@ test('Architect v6 (HTTP)', async t => {
 
   let res = await run(responses.arc6.http.noReturn, request)
   t.equal(res.body, '', 'Empty body passed')
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.emptyReturn, request)
   t.equal(res.body, '', 'Empty body passed')
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.string, request)
   t.equal(str(responses.arc6.http.string), res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.object, request)
   t.equal(str(responses.arc6.http.object), res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.array, request)
   t.equal(str(responses.arc6.http.array), res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.buffer, request)
   t.equal(str(responses.arc6.http.buffer), res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.number, request)
   t.equal(str(responses.arc6.http.number), res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.bodyOnly, request)
   t.equal(responses.arc6.http.bodyOnly.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.bodyWithStatus, request)
   t.equal(responses.arc6.http.bodyWithStatus.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.bodyWithStatusAndContentType, request)
   t.equal(responses.arc6.http.bodyWithStatusAndContentType.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.encodedWithBinaryType, request)
   t.equal(responses.arc6.http.encodedWithBinaryType.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/pdf'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/pdf/, 'Actual content type returned in header')
   t.ok(res.isBase64Encoded, 'isBase64Encoded param passed through')
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.cookies, request)
   t.equal(responses.arc6.http.cookies.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(str(responses.arc6.http.cookies.cookies), str(res.cookies), match('res.cookies', res.cookies))
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.secureCookies, request)
   t.equal(responses.arc6.http.secureCookies.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(str(responses.arc6.http.secureCookies.cookies), str(res.cookies), match('res.cookies', res.cookies))
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc6.http.secureCookieHeader, request)
   t.equal(responses.arc6.http.secureCookieHeader.body, res.body, match('res.body', res.body))
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(responses.arc6.rest.secureCookieHeader.headers['set-cookie'], res.headers['set-cookie'], match(`res.headers['set-cookie']`, res.headers['set-cookie']))
   t.equal(res.statusCode, 200, 'Responded with 200')
 
@@ -275,7 +275,7 @@ test('Architect v5 (REST) + Functions', async t => {
   t.equal(res.statusCode, 200, 'Responded with 200')
 
   res = await run(responses.arc5.defaultsToJson, request)
-  t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+  t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
   t.equal(res.statusCode, 200, 'Responded with 200')
 })
 
@@ -373,7 +373,7 @@ test('Architect <6 response params', async t => {
   t.equal(responses.arc.statusCode.statusCode, res.statusCode, match('status', res.statusCode))
 
   res = await run(responses.arc.session, request)
-  t.ok(res.headers['Set-Cookie'].includes('_idx='), `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
+  t.match(res.headers['Set-Cookie'], /_idx=/, `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
 })
 
 test('Should prevent further middleware from running when a response is returned', t => {

--- a/test/unit/src/http/http-res-test.js
+++ b/test/unit/src/http/http-res-test.js
@@ -44,88 +44,88 @@ test('Architect v6 (HTTP)', t => {
   run(responses.arc6.http.noReturn, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(res.body, '', 'Empty body passed')
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.emptyReturn, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(res.body, '', 'Empty body passed')
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.string, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(str(responses.arc6.http.string), res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.object, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(str(responses.arc6.http.object), res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.array, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(str(responses.arc6.http.array), res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.buffer, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(str(responses.arc6.http.buffer), res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.number, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(str(responses.arc6.http.number), res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.bodyOnly, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.bodyOnly.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.bodyWithStatus, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.bodyWithStatus.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.bodyWithStatusAndContentType, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.bodyWithStatusAndContentType.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.encodedWithBinaryType, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.encodedWithBinaryType.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/pdf'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/pdf/, 'Unspecified content type defaults to JSON')
     t.ok(res.isBase64Encoded, 'isBase64Encoded param passed through')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.cookies, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.cookies.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(str(responses.arc6.http.cookies.cookies), str(res.cookies), match('res.cookies', res.cookies))
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.secureCookies, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.secureCookies.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(str(responses.arc6.http.secureCookies.cookies), str(res.cookies), match('res.cookies', res.cookies))
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.http.secureCookieHeader, request, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(responses.arc6.http.secureCookieHeader.body, res.body, match('res.body', res.body))
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(responses.arc6.rest.secureCookieHeader.headers['set-cookie'], res.headers['set-cookie'], match(`res.headers['set-cookie']`, res.headers['set-cookie']))
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
@@ -300,7 +300,7 @@ test('Architect v5 (REST) + Functions', t => {
   })
   run(responses.arc5.defaultsToJson, request, (err, res) => {
     t.notOk(err, 'No error')
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
 })
@@ -434,7 +434,7 @@ test('Architect v4-style + Functions statically-bound content type responses (RE
         t.equal(str(data), res.body, match('res.body', res.body))
       else
         t.equal(str(data), str(res.body), match('res.body', res.body))
-      t.true(res.headers['Content-Type'].includes(contentType), `Correct Content-Type header sent: ${contentType}`)
+      t.match(res.headers['Content-Type'], new RegExp(contentType), `Correct Content-Type header sent: ${contentType}`)
       t.equal(res.statusCode, 200, 'Responded with 200')
     })
   }
@@ -459,7 +459,7 @@ test('Architect v4-style + Functions statically-bound content type responses (HT
         t.equal(str(data), res.body, match('res.body', res.body))
       else
         t.equal(str(data), str(res.body), match('res.body', res.body))
-      t.true(res.headers['Content-Type'].includes(contentType), `Correct Content-Type header sent: ${contentType}`)
+      t.match(res.headers['Content-Type'], new RegExp(contentType), `Correct Content-Type header sent: ${contentType}`)
       t.equal(res.statusCode, 200, 'Responded with 200')
     })
   }
@@ -494,7 +494,7 @@ test('Architect <6 + Functions old school response params (HTTP)', t => {
   })
   run(responses.arc.session, request, (err, res) => {
     t.notOk(err, 'No error')
-    t.ok(res.headers['Set-Cookie'].includes('_idx='), `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
+    t.match(res.headers['Set-Cookie'], /_idx=/, `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
   })
 })
 
@@ -521,7 +521,7 @@ test('Architect <6 + Functions old school response params (REST)', t => {
   })
   run(responses.arc.session, request, (err, res) => {
     t.notOk(err, 'No error')
-    t.ok(res.headers['Set-Cookie'].includes('_idx='), `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
+    t.match(res.headers['Set-Cookie'], /_idx=/, `Cookie set: ${res.headers['Set-Cookie'].substr(0, 75)}...`)
   })
 })
 
@@ -533,7 +533,7 @@ test('Test errors', t => {
   handler(request, {}, (err, res) => {
     t.notOk(err, 'No error')
     t.equal(res.statusCode, 500, 'Error response, 500 returned')
-    t.ok(res.body.includes(error.message), `Error response included error message: ${error.message}`)
+    t.match(res.body, new RegExp(error.message), `Error response included error message: ${error.message}`)
   })
 })
 

--- a/test/unit/src/http/proxy/format/response-test.js
+++ b/test/unit/src/http/proxy/format/response-test.js
@@ -74,22 +74,22 @@ test('Cache-Control setting', t => {
   // JSON
   _basicResponse.response.headers['Content-Type'] = 'application/json'
   result = normalize(_basicResponse)
-  t.ok(result.headers['Cache-Control'].includes('no-cache'), 'JSON responses are anti-cached')
+  t.match(result.headers['Cache-Control'], /no-cache/, 'JSON responses are anti-cached')
 
   // JSON API
   _basicResponse.response.headers['Content-Type'] = 'application/vnd.api+json'
   result = normalize(_basicResponse)
-  t.ok(result.headers['Cache-Control'].includes('no-cache'), 'JSON API responses are anti-cached')
+  t.match(result.headers['Cache-Control'], /no-cache/, 'JSON API responses are anti-cached')
 
   // HTML
   _basicResponse.response.headers['Content-Type'] = 'text/html'
   result = normalize(_basicResponse)
-  t.ok(result.headers['Cache-Control'].includes('no-cache'), 'HTML responses are anti-cached')
+  t.match(result.headers['Cache-Control'], /no-cache/, 'HTML responses are anti-cached')
 
   // cacheControl param sets Cache-Control (and overrides anti-cache)
   _basicResponse.config.cacheControl = 'meh'
   result = normalize(_basicResponse)
-  t.ok(result.headers['Cache-Control'].includes('meh'), 'cacheControl setting is respected and wins over anti-cache logic')
+  t.match(result.headers['Cache-Control'], /meh/, 'cacheControl setting is respected and wins over anti-cache logic')
 
 })
 

--- a/test/unit/src/http/proxy/format/templatize-test.js
+++ b/test/unit/src/http/proxy/format/templatize-test.js
@@ -26,18 +26,18 @@ test('Templatizer passes through non-fingerprinted assets', t => {
   t.plan(6)
   let response = { body: buf('here is an asset: ${STATIC(\'this-is-fine.gif\')}') }
   let result = sut({ response }).body.toString()
-  t.notOk(result.includes('${STATIC(\'this-is-fine.gif\')}'), 'Templatizer stripped out STATIC')
-  t.ok(result.includes('this-is-fine.gif'), 'Templatizer left in asset reference')
+  t.doesNotMatch(result, /${STATIC(\'this-is-fine.gif\')}/, 'Templatizer stripped out STATIC')
+  t.match(result, /this-is-fine.gif/, 'Templatizer left in asset reference')
 
   response = { body: buf('here is an asset: ${arc.static(\'this-is-fine.gif\')}') }
   result = sut({ response }).body.toString()
-  t.notOk(result.includes('${arc.static(\'this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes('this-is-fine.gif'), 'Templatizer left in asset reference')
+  t.doesNotMatch(result, /${arc.static(\'this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, /this-is-fine.gif/, 'Templatizer left in asset reference')
 
   response = { body: buf('here is an asset: ${arc.static(\'/this-is-fine.gif\')}') }
   result = sut({ response }).body.toString()
-  t.notOk(result.includes('${arc.static(\'/this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes('/this-is-fine.gif'), 'Templatizer left in asset reference (including leading slash)')
+  t.doesNotMatch(result, /${arc.static(\'\/this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, /\/this-is-fine.gif/, 'Templatizer left in asset reference (including leading slash)')
 })
 
 test('Templatizer replaces fingerprinted assets', t => {
@@ -48,20 +48,20 @@ test('Templatizer replaces fingerprinted assets', t => {
   }
   let response = { body: buf('here is an asset: ${STATIC(\'this-is-fine.gif\')}') }
   let result = sut({ response, assets }).body.toString()
-  t.notOk(result.includes('${STATIC(\'this-is-fine.gif\')}'), 'Templatizer stripped out STATIC')
-  t.ok(result.includes(fingerprinted), 'Templatizer replaced asset reference with fingerprint')
+  t.doesNotMatch(result, /${STATIC(\'this-is-fine.gif\')}/, 'Templatizer stripped out STATIC')
+  t.match(result, new RegExp(fingerprinted), 'Templatizer replaced asset reference with fingerprint')
 
   response = { body: buf('here is an asset: ${arc.static(\'this-is-fine.gif\')}') }
   result = sut({ response, assets }).body.toString()
-  t.notOk(result.includes('${arc.static(\'this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes(fingerprinted), 'Templatizer replaced asset reference with fingerprint')
+  t.doesNotMatch(result, /${arc.static(\'this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, new RegExp(fingerprinted), 'Templatizer replaced asset reference with fingerprint')
 
   // Leading slash
   fingerprinted = '/this-is-fine-abc123.gif'
   response = { body: buf('here is an asset: ${arc.static(\'/this-is-fine.gif\')}') }
   result = sut({ response, assets }).body.toString()
-  t.notOk(result.includes('${arc.static(\'/this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes(fingerprinted), 'Templatizer replaced asset reference with fingerprint (including leading slash)')
+  t.doesNotMatch(result, /${arc.static(\'\/this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, new RegExp(fingerprinted), 'Templatizer replaced asset reference with fingerprint (including leading slash)')
 })
 
 test('Templatizer does not replace fingerprinted assets locally', t => {
@@ -72,16 +72,16 @@ test('Templatizer does not replace fingerprinted assets locally', t => {
   let isLocal = true
   let response = { body: buf('here is an asset: ${STATIC(\'this-is-fine.gif\')}') }
   let result = sut({ response, assets, isLocal }).body.toString()
-  t.notOk(result.includes('${STATIC(\'this-is-fine.gif\')}'), 'Templatizer stripped out STATIC')
-  t.ok(result.includes('this-is-fine.gif'), 'Templatizer replaced asset reference with fingerprint')
+  t.doesNotMatch(result, /${STATIC(\'this-is-fine.gif\')}/, 'Templatizer stripped out STATIC')
+  t.match(result, /this-is-fine.gif/, 'Templatizer replaced asset reference with fingerprint')
 
   response = { body: buf('here is an asset: ${arc.static(\'this-is-fine.gif\')}') }
   result = sut({ response, assets, isLocal }).body.toString()
-  t.notOk(result.includes('${arc.static(\'this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes('this-is-fine.gif'), 'Templatizer replaced asset reference with fingerprint')
+  t.doesNotMatch(result, /${arc.static(\'this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, /this-is-fine.gif/, 'Templatizer replaced asset reference with fingerprint')
 
   response = { body: buf('here is an asset: ${arc.static(\'/this-is-fine.gif\')}') }
   result = sut({ response, assets, isLocal }).body.toString()
-  t.notOk(result.includes('${arc.static(\'/this-is-fine.gif\')}'), 'Templatizer stripped out arc.static')
-  t.ok(result.includes('/this-is-fine.gif'), 'Templatizer replaced asset reference with fingerprint (including leading slash)')
+  t.doesNotMatch(result, /${arc.static(\'\/this-is-fine.gif\')}/, 'Templatizer stripped out arc.static')
+  t.match(result, /\/this-is-fine.gif/, 'Templatizer replaced asset reference with fingerprint (including leading slash)')
 })

--- a/test/unit/src/http/proxy/index-test.js
+++ b/test/unit/src/http/proxy/index-test.js
@@ -28,7 +28,7 @@ test('Config: bucket', async t => {
   // Test no bucket config
   let result = await proxy(req)
   t.equal(result.statusCode, 502, 'Missing bucket config responds with 502')
-  t.ok(result.body.includes('Index not found'), 'Missing bucket config presents helpful error')
+  t.match(result.body, /Index not found/, 'Missing bucket config presents helpful error')
 
   // Test ARC_STATIC_BUCKET
   process.env.ARC_STATIC_BUCKET = productionBucket

--- a/test/unit/src/http/proxy/read/_local-test.js
+++ b/test/unit/src/http/proxy/read/_local-test.js
@@ -179,8 +179,8 @@ test('Local proxy reader templatizes with local paths when fingerprinting is ena
   let params = read({ Key: mdName, config: { assets: staticStub } })
   let result = await readLocal(params)
   t.notEqual(result.body, b64(mdContents), `Contents containing template calls mutated: ${dec(result.body)}`)
-  t.ok(dec(result.body).includes(imgName), `Used non-fingerprinted filename in sandbox mode: ${imgName}`)
-  t.notOk(dec(result.body).includes(staticStub[imgName]), `Did not use fingerprinted filename in sandbox mode: ${staticStub[imgName]}`)
+  t.match(dec(result.body), new RegExp(imgName), `Used non-fingerprinted filename in sandbox mode: ${imgName}`)
+  t.doesNotMatch(dec(result.body), new RegExp(staticStub[imgName]), `Did not use fingerprinted filename in sandbox mode: ${staticStub[imgName]}`)
   reset()
 })
 

--- a/test/unit/src/http/proxy/read/_pretty-test.js
+++ b/test/unit/src/http/proxy/read/_pretty-test.js
@@ -123,7 +123,7 @@ test('Peek and do not find nested index.html', async t => {
     isFolder
   })
   t.equal(result.statusCode, 404, 'Returns statusCode of 404 if S3 file is not found')
-  t.ok(result.body.includes('NoSuchKey'), 'Error message included in response from S3')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from S3')
 
   // Local
   process.env.NODE_ENV = 'testing'
@@ -134,7 +134,7 @@ test('Peek and do not find nested index.html', async t => {
     isFolder
   })
   t.equal(result.statusCode, 404, 'Returns statusCode of 404 if local file is not found')
-  t.ok(result.body.includes('NoSuchKey'), 'Error message included in response from local')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from local')
   reset()
 })
 
@@ -208,7 +208,7 @@ test('Return the default 404', async t => {
     isFolder
   })
   t.equal(result.statusCode, 404, 'Returns statusCode of 404 if S3 file is not found')
-  t.ok(result.body.includes('NoSuchKey'), 'Error message included in response from S3')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from S3')
 
   // Local
   process.env.NODE_ENV = 'staging'
@@ -223,7 +223,7 @@ test('Return the default 404', async t => {
     isFolder
   })
   t.equal(result.statusCode, 404, 'Returns statusCode of 404 if local file is not found')
-  t.ok(result.body.includes('NoSuchKey'), 'Error message included in response from local')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from local')
   reset()
 })
 

--- a/test/unit/src/http/proxy/read/_s3-test.js
+++ b/test/unit/src/http/proxy/read/_s3-test.js
@@ -263,8 +263,8 @@ test('Fingerprint: template calls are replaced inline on non-captured requests',
   t.equal(options.Bucket, Bucket, `Used alternate bucket: ${options.Bucket}`)
   t.equal(options.Key, Key, `Read fingerprinted filename: ${options.Key}`)
   t.notEqual(fileContents, dec(result.body), `Contents containing template calls mutated: ${dec(result.body)}`)
-  t.ok(dec(result.body).includes(staticStub['images/this-is-fine.gif']), `Contents now include fingerprinted asset: ${staticStub['images/this-is-fine.gif']}`)
-  t.ok(dec(result.body).includes(staticStub['images/hold-onto-your-butts.gif']), `Contents now include fingerprinted asset: ${staticStub['images/hold-onto-your-butts.gif']}`)
+  t.match(dec(result.body), new RegExp(staticStub['images/this-is-fine.gif']), `Contents now include fingerprinted asset: ${staticStub['images/this-is-fine.gif']}`)
+  t.match(dec(result.body), new RegExp(staticStub['images/hold-onto-your-butts.gif']), `Contents now include fingerprinted asset: ${staticStub['images/hold-onto-your-butts.gif']}`)
 })
 
 test('Fingerprint: template calls are replaced inline on captured requests', async t => {
@@ -280,8 +280,8 @@ test('Fingerprint: template calls are replaced inline on captured requests', asy
   t.equal(options.Bucket, Bucket, `Used alternate bucket: ${options.Bucket}`)
   t.equal(options.Key, staticStub[Key], `Read fingerprinted filename: ${options.Key}`)
   t.notEqual(fileContents, result.body, `Contents containing template calls mutated: ${result.body}`)
-  t.ok(dec(result.body).includes(staticStub['images/this-is-fine.gif']), `Contents now include fingerprinted asset: ${staticStub['images/this-is-fine.gif']}`)
-  t.ok(dec(result.body).includes(staticStub['images/hold-onto-your-butts.gif']), `Contents now include fingerprinted asset: ${staticStub['images/hold-onto-your-butts.gif']}`)
+  t.match(dec(result.body), new RegExp(staticStub['images/this-is-fine.gif']), `Contents now include fingerprinted asset: ${staticStub['images/this-is-fine.gif']}`)
+  t.match(dec(result.body), new RegExp(staticStub['images/hold-onto-your-butts.gif']), `Contents now include fingerprinted asset: ${staticStub['images/hold-onto-your-butts.gif']}`)
 })
 
 test('S3 proxy reader hands off to pretty URLifier on 404', async t => {
@@ -299,6 +299,6 @@ test('S3 proxy reader returns 500 error on S3 error', async t => {
   errorState = 'this is a random error state'
   let result = await readS3(read())
   t.equal(result.statusCode, 500, 'Returns statusCode of 500 if S3 errors')
-  t.ok(result.body.includes(errorState), 'Error message included in response')
+  t.match(result.body, new RegExp(errorState), 'Error message included in response')
   errorState = false
 })

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -24,11 +24,11 @@ test('jwe read and write implementations', async t => {
   t.comment(JSON.stringify(session))
   t.comment(JSON.stringify(cookie))
   t.comment(JSON.stringify(inception))
-  t.ok(inception.one === 1, 'read back again')
+  t.equal(inception.one, 1, 'read back again')
   // Lambda payload version 2
   let inception2 = await read({ cookies: [ cookie ] })
-  t.ok(inception2.one === 1, 'read back again from payload version 2')
-  t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
+  t.equal(inception2.one, 1, 'read back again from payload version 2')
+  t.match(cookie, new RegExp(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
 test('jwe SameSite is configurable', async t => {
@@ -39,11 +39,11 @@ test('jwe SameSite is configurable', async t => {
   // default value:
   delete process.env.ARC_SESSION_SAME_SITE
   let cookie = await write(session)
-  t.ok(cookie.includes(`SameSite=Lax`), 'cookie SameSite is set correctly to default')
+  t.match(cookie, /SameSite=Lax/, 'cookie SameSite is set correctly to default')
   // configured value:
   process.env.ARC_SESSION_SAME_SITE = 'None'
   cookie = await write(session)
-  t.ok(cookie.includes(`SameSite=${process.env.ARC_SESSION_SAME_SITE}`), 'cookie SameSite is set correctly to configured value')
+  t.match(cookie, new RegExp(`SameSite=${process.env.ARC_SESSION_SAME_SITE}`), 'cookie SameSite is set correctly to configured value')
 })
 
 test('set up sandbox for ddb testing', t => {
@@ -72,8 +72,8 @@ test('ddb read and write implementations', async t => {
   t.equals(inception.one, 1, 'read back modified cookie')
   // Lambda payload version 2
   let inception2 = await read({ cookies: [ cookie ] })
-  t.ok(inception2.one === 1, 'read back again from payload version 2')
-  t.ok(cookie.includes(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
+  t.equals(inception2.one, 1, 'read back again from payload version 2')
+  t.match(cookie, new RegExp(`Max-Age=${process.env.SESSION_TTL}`), 'cookie max-age is set correctly')
 })
 
 test('shutdown sandbox', t => {


### PR DESCRIPTION
relates to architect/architect#1146
