### PR TITLE
chore: upgrade arc/eslint-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,16 @@
     "uid-safe": "^2.1.5"
   },
   "devDependencies": {
-    "@architect/eslint-config": "1.0.1",
+    "@architect/eslint-config": "^2.0.1",
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
     "@architect/sandbox": "~4.2.0",
     "aws-sdk": "~2.880.0",
     "aws-sdk-mock": "~5.4.0",
     "cross-env": "~7.0.3",
-    "eslint": "~8.0.0",
+    "eslint": "^8.2.0",
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-fp": "^2.3.0",
+    "eslint-plugin-import": "^2.25.3",
     "mock-fs": "~5.1.1",
     "nyc": "~15.1.0",
     "proxyquire": "~2.1.3",

--- a/src/events/subscribe.js
+++ b/src/events/subscribe.js
@@ -22,7 +22,7 @@ module.exports = function _subscribe (fn) {
   if (fn.constructor.name === 'AsyncFunction') {
     return async function lambda (event) {
       event = event && Object.keys(event).length ? event : fallback
-      return await Promise.all(event.Records.map(async record => {
+      return Promise.all(event.Records.map(async record => {
         try {
           let result = JSON.parse(record.Sns.Message)
           return await fn(result)

--- a/src/queues/subscribe.js
+++ b/src/queues/subscribe.js
@@ -21,7 +21,7 @@ let parallel = require('run-parallel')
 module.exports = function _subscribe (fn) {
   if (fn.constructor.name === 'AsyncFunction') {
     return async function lambda (event) {
-      return await Promise.all(event.Records.map(async record => {
+      return Promise.all(event.Records.map(async record => {
         try {
           let result = JSON.parse(record.body)
           return await fn(result)


### PR DESCRIPTION
- in npm 7+ peer deps that are also deps don't get installed by default so we have to install
- fix a linting issue with the new config

Fixes linting on node 16 and npm 8

# tasks 

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes