### PR TITLE
Enable Functions v5 to be used as a bare module in test suites without setting env vars

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -4,6 +4,20 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/main/changelog.md)
 ---
 
+## [5.0.3] 2022-02-24
+
+### Added
+
+- Enable Functions v5 to be used as a bare module in test suites without setting env vars (see `ARC_ENV` requirement below)
+  - Functions now makes a best-effort attempt to find Sandbox ports via internal SSM
+
+
+### Changed
+
+- Relax requirement for `ARC_ENV` env var; backfill it to `testing` if not found
+
+---
+
 ## [5.0.0 - 5.0.2] 2022-01-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@architect/eslint-config": "1.0.1",
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
-    "@architect/sandbox": "^5.0.0",
+    "@architect/sandbox": "^5.0.3-RC.0",
     "aws-sdk": "~2.880.0",
     "aws-sdk-mock": "~5.6.2",
     "cross-env": "~7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "5.0.2",
+  "version": "5.0.3-RC.0",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,10 @@ let { sandboxVersionAtLeast } = require('./lib/version')
  */
 let { ARC_ENV, ARC_SANDBOX } = process.env
 let validEnvs = [ 'testing', 'staging', 'production' ]
+// Backfill ARC_ENV if Functions is running outside of Sandbox in a test suite
+if (!ARC_ENV) {
+  process.env.ARC_ENV = ARC_ENV = 'testing'
+}
 if (!validEnvs.includes(ARC_ENV)) {
   throw ReferenceError(`ARC_ENV env var is required for use with @architect/functions`)
 }

--- a/src/lib/get-ports.js
+++ b/src/lib/get-ports.js
@@ -1,0 +1,27 @@
+let discovery = require('../discovery')
+
+module.exports = function getPorts (callback) {
+  let { ARC_SANDBOX } = process.env
+  let notFound = ReferenceError('Sandbox internal port not found')
+  // Sandbox env var is the happy path for Lambda runs
+  if (ARC_SANDBOX) {
+    let { ports } = JSON.parse(ARC_SANDBOX)
+    if (!ports) {
+      return callback(notFound)
+    }
+    callback(null, ports)
+  }
+  // Fall back to an internal SSM query in case Functions is running as a bare module
+  else {
+    discovery((err, services) => {
+      if (err) callback(err)
+      else {
+        if (!services.ARC_SANDBOX || !services.ARC_SANDBOX.ports) {
+          return callback(notFound)
+        }
+        let ports = JSON.parse(services.ARC_SANDBOX.ports)
+        callback(null, ports)
+      }
+    })
+  }
+}

--- a/test/integration/static-fingerprinted-test.js
+++ b/test/integration/static-fingerprinted-test.js
@@ -13,9 +13,7 @@ let static
 
 test('Set up mocked arc', t => {
   t.plan(2)
-  process.env.ARC_ENV = 'testing'
   process.env.AWS_REGION = 'us-west-1'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   mkdir(shared, { recursive: true })
   copyFileSync(join(mock, 'mock-arc-fingerprint'), join(shared, '.arc'))
   copyFileSync(join(mock, 'mock-arc-fingerprint'), join(tmp, '.arc'))
@@ -44,7 +42,7 @@ test('Set up mocked static manifest', t => {
 test('Clean up env', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
+  delete process.env.AWS_REGION
   process.chdir(origCwd)
   exec(`rm -rf ${tmp}`)
   t.ok(!exists(tmp), 'Mocks cleaned up')

--- a/test/integration/static-plain-test.js
+++ b/test/integration/static-plain-test.js
@@ -17,7 +17,6 @@ let resetEnv = () => {
 test('Set up mocked files', t => {
   t.plan(2)
   process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   mkdir(shared, { recursive: true })
   copyFileSync(join(mock, 'mock-arc'), join(shared, '.arc'))
   copyFileSync(join(mock, 'mock-arc'), join(tmp, '.arc'))
@@ -52,7 +51,6 @@ test('Local URL tests', t => {
 test('Clean up env', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   process.chdir(origCwd)
   exec(`rm -rf ${tmp}`)
   t.ok(!exists(tmp), 'Mocks cleaned up')

--- a/test/integration/tables-test.js
+++ b/test/integration/tables-test.js
@@ -14,8 +14,6 @@ let shared = join(tmp, 'node_modules', '@architect', 'shared')
 test('Set up mocked files', t => {
   t.plan(3)
   process.env.ARC_APP_NAME = 'test'
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: { tables: 5555, _arc: 2222 } })
   mkdir(shared, { recursive: true })
   copyFileSync(join(mock, 'mock-arc'), join(shared, '.arc'))
   copyFileSync(join(mock, 'mock-arc'), join(tmp, '.arc'))
@@ -190,7 +188,6 @@ test('Clean up env', t => {
   t.plan(1)
   delete process.env.ARC_APP_NAME
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   exec(`rm -rf ${tmp}`)
   t.ok(!exists(tmp), 'Mocks cleaned up')
 })

--- a/test/unit/src/discovery/index-test.js
+++ b/test/unit/src/discovery/index-test.js
@@ -7,7 +7,6 @@ let discovery = require('../../../../src/discovery')
 test('Set up env', t => {
   t.plan(1)
   process.env.ARC_APP_NAME = 'test'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   t.pass('Set up ARC_APP_NAME env var')
 })
 
@@ -90,6 +89,5 @@ test('discovery should parse several pages of hierarchical SSM parameters into a
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_APP_NAME
-  delete process.env.ARC_SANDBOX
   t.pass('Done!')
 })

--- a/test/unit/src/events/publish-test.js
+++ b/test/unit/src/events/publish-test.js
@@ -3,8 +3,6 @@ let publish
 
 test('Set up env', t => {
   t.plan(1)
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   // eslint-disable-next-line
   let arc = require('../../../..')
   publish = arc.events.publish
@@ -24,6 +22,5 @@ test('events.publish should throw if there is no parameter payload', t => {
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   t.pass('Done!')
 })

--- a/test/unit/src/events/subscribe-test.js
+++ b/test/unit/src/events/subscribe-test.js
@@ -4,8 +4,6 @@ let subscribe
 
 test('Set up env', t => {
   t.plan(1)
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   // eslint-disable-next-line
   let arc = require('../../../..')
   subscribe = arc.events.subscribe
@@ -65,6 +63,5 @@ test('events.subscribe should fall back to an empty event if one is not provided
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   t.pass('Done!')
 })

--- a/test/unit/src/http/async/index-req-test.js
+++ b/test/unit/src/http/async/index-req-test.js
@@ -61,8 +61,6 @@ function check ({ req, request, t }) {
 test('Set up env', t => {
   t.plan(1)
   // Set env var to keep from stalling on db reads in CI
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   process.env.ARC_SESSION_TABLE_NAME = 'jwe'
   // eslint-disable-next-line
   arc = require(sut)

--- a/test/unit/src/http/async/index-res-test.js
+++ b/test/unit/src/http/async/index-res-test.js
@@ -29,8 +29,6 @@ let run = async (response, request) => {
 test('Set up env', t => {
   t.plan(1)
   // Set env var to keep from stalling on db reads in CI
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   process.env.ARC_SESSION_TABLE_NAME = 'jwe'
   // eslint-disable-next-line
   arc = require(sut)
@@ -456,7 +454,6 @@ test('Verify all Arc v7 (HTTP) + Arc v6 (REST) + legacy response fixtures were t
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   delete process.env.ARC_SESSION_TABLE_NAME
   t.pass('Done')
 })

--- a/test/unit/src/http/http-req-test.js
+++ b/test/unit/src/http/http-req-test.js
@@ -65,8 +65,6 @@ function check ({ req, request, res, t }) {
 test('Set up env', t => {
   t.plan(1)
   // Set env var to keep from stalling on db reads in CI
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   process.env.ARC_SESSION_TABLE_NAME = 'jwe'
   // eslint-disable-next-line
   let arc = require(sut)
@@ -390,7 +388,6 @@ test('Verify all Arc v7 (HTTP) + Arc v6 (REST) request fixtures were tested', t 
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   delete process.env.ARC_SESSION_TABLE_NAME
   t.pass('Done')
 })

--- a/test/unit/src/http/http-res-test.js
+++ b/test/unit/src/http/http-res-test.js
@@ -26,8 +26,6 @@ let run = (response, request, callback) => {
 test('Set up env', t => {
   t.plan(1)
   // Init env var to keep from stalling on db reads in CI
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   process.env.ARC_SESSION_TABLE_NAME = 'jwe'
   // eslint-disable-next-line
   let arc = require(sut)
@@ -490,7 +488,6 @@ test('Verify all Arc v7 (HTTP) + Arc v6 (REST) + legacy response fixtures were t
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   delete process.env.ARC_SESSION_TABLE_NAME
   t.pass('Done')
 })

--- a/test/unit/src/http/session/session-test.js
+++ b/test/unit/src/http/session/session-test.js
@@ -5,8 +5,6 @@ let read, write
 
 test('http.session apis exist', t => {
   t.plan(2)
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: { tables: 5555 } })
   // eslint-disable-next-line
   let arc = require('../../../../../')
   read = arc.http.session.read
@@ -84,7 +82,6 @@ test('ddb read and write implementations', async t => {
 test('shutdown sandbox', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   delete process.env.ARC_SESSION_TABLE_NAME
   delete process.env.ARC_SESSION_TTL
   sandbox.end(err => {

--- a/test/unit/src/queues/publish-test.js
+++ b/test/unit/src/queues/publish-test.js
@@ -3,8 +3,6 @@ let publish
 
 test('Set up env', t => {
   t.plan(1)
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   // eslint-disable-next-line
   let arc = require('../../../..')
   publish = arc.queues.publish
@@ -24,6 +22,5 @@ test('queues.publish should throw if there is no parameter payload', t => {
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   t.pass('Done!')
 })

--- a/test/unit/src/queues/subscribe-test.js
+++ b/test/unit/src/queues/subscribe-test.js
@@ -5,8 +5,6 @@ let subscribe
 
 test('Set up env', t => {
   t.plan(1)
-  process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   // eslint-disable-next-line
   let arc = require('../../../..')
   subscribe = arc.queues.subscribe
@@ -52,6 +50,5 @@ test('queues.subscribe calls async handler', async t => {
 test('Teardown', t => {
   t.plan(1)
   delete process.env.ARC_ENV
-  delete process.env.ARC_SANDBOX
   t.pass('Done!')
 })

--- a/test/unit/src/static/index-test.js
+++ b/test/unit/src/static/index-test.js
@@ -25,7 +25,6 @@ test('Local env returns non-fingerprinted path', t => {
   reset()
   manifestExists = true
   process.env.ARC_ENV = 'testing'
-  process.env.ARC_SANDBOX = JSON.stringify({ ports: {}, version: '5.0.0' })
   let asset = arcStatic('foo.png')
   t.equal(asset, '/_static/foo.png', 'Returned non-fingerprinted path')
   asset = arcStatic('/foo.png')
@@ -82,6 +81,5 @@ test('Passing stagePath option adds API Gateway /staging or /production to path'
 
 test('Reset', t => {
   reset()
-  delete process.env.ARC_SANDBOX
   t.end()
 })


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
