### PR TITLE
Deep require `aws-sdk` deps for a potentially large cold start perf boost

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -4,6 +4,15 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/main/changelog.md)
 ---
 
+## [next] 2022-02-24
+
+### Changed
+
+- Deep require `aws-sdk` deps for a potentially large cold start perf boost
+  - In small-scale testing, we found this can further reduce cold start performance by 2.5-5x, averaging ~150ms on Lambda
+
+---
+
 ## [5.0.3] 2022-02-24
 
 ### Added

--- a/_changelog.md
+++ b/_changelog.md
@@ -4,12 +4,17 @@
 Also see: [Architect changelog](https://github.com/architect/architect/blob/main/changelog.md)
 ---
 
-## [next] 2022-02-24
+## [5.0.4] 2022-02-24
 
 ### Changed
 
 - Deep require `aws-sdk` deps for a potentially large cold start perf boost
   - In small-scale testing, we found this can further reduce cold start performance by 2.5-5x, averaging ~150ms on Lambda
+
+
+### Fixed
+
+- Fixed usage with custom stack names; fixes #1322, thanks @Lugana707, @pgte
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
     "@architect/sandbox": "^5.0.3-RC.0",
     "aws-sdk": "~2.880.0",
-    "aws-sdk-mock": "~5.6.2",
     "cross-env": "~7.0.3",
     "eslint": "~8.9.0",
     "mock-fs": "~5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "5.0.4-RC.1",
+  "version": "5.0.4-RC.2",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "devDependencies": {
     "@architect/eslint-config": "1.0.1",
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
-    "@architect/sandbox": "^5.0.3-RC.0",
+    "@architect/sandbox": "^5.1.0-RC.0",
     "aws-sdk": "~2.880.0",
     "cross-env": "~7.0.3",
-    "eslint": "~8.9.0",
+    "eslint": "~8.10.0",
     "mock-fs": "~5.1.2",
     "nyc": "~15.1.0",
     "proxyquire": "~2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "5.0.3",
+  "version": "5.0.4-RC.0",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "5.0.4-RC.0",
+  "version": "5.0.4-RC.1",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
   "repository": {

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -5,9 +5,9 @@ let http = require('http')
  * @returns {object} {name: value}
  */
 module.exports = function lookup (callback) {
-  // We really only want to load aws-sdk if absolutely necessary
+  // We really only want to load aws-sdk if absolutely necessary, and only the client we need
   // eslint-disable-next-line
-  let aws = require('aws-sdk')
+  let SSM = require('aws-sdk/clients/ssm')
   let { ARC_APP_NAME: app, ARC_ENV: env, ARC_SANDBOX, AWS_REGION } = process.env
   let local = env === 'testing'
   if (!local && !app) {
@@ -30,14 +30,13 @@ module.exports = function lookup (callback) {
       }
       port = ports._arc
     }
-    let region = AWS_REGION || 'us-west-2'
     config = {
-      endpoint: new aws.Endpoint(`http://localhost:${port}/_arc/ssm`),
-      region,
+      endpoint: `http://localhost:${port}/_arc/ssm`,
+      region: AWS_REGION || 'us-west-2',
       httpOptions: { agent: new http.Agent() }
     }
   }
-  let ssm = new aws.SSM(config)
+  let ssm = new SSM(config)
 
   function getParams (params) {
     ssm.getParametersByPath(params, function done (err, result) {

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -1,5 +1,3 @@
-let http = require('http')
-
 /**
  * @param {string} type - events, queues, or tables
  * @returns {object} {name: value}
@@ -8,15 +6,15 @@ module.exports = function lookup (callback) {
   // We really only want to load aws-sdk if absolutely necessary, and only the client we need
   // eslint-disable-next-line
   let SSM = require('aws-sdk/clients/ssm')
-  let { ARC_APP_NAME: app, ARC_ENV: env, ARC_SANDBOX, AWS_REGION } = process.env
+  let { ARC_APP_NAME: app, ARC_ENV: env, ARC_SANDBOX, ARC_STACK_NAME: stack, AWS_REGION } = process.env
   let local = env === 'testing'
-  if (!local && !app) {
-    return callback(ReferenceError('ARC_APP_NAME env var not found'))
+  if (!local && !app && !stack) {
+    return callback(ReferenceError('ARC_APP_NAME and ARC_STACK_NAME env vars not found'))
   }
   if (local && !app) {
     app = 'arc-app'
   }
-  let Path = '/' + toLogicalID(`${app}-${env}`)
+  let Path = `/${stack || toLogicalID(`${app}-${env}`)}`
   let Recursive = true
   let values = []
   let config
@@ -33,7 +31,6 @@ module.exports = function lookup (callback) {
     config = {
       endpoint: `http://localhost:${port}/_arc/ssm`,
       region: AWS_REGION || 'us-west-2',
-      httpOptions: { agent: new http.Agent() }
     }
   }
   let ssm = new SSM(config)

--- a/src/events/publish.js
+++ b/src/events/publish.js
@@ -76,12 +76,12 @@ function _publishSandbox (type, params, callback) {
 
 function eventFactory (arc) {
   return function live ({ name, payload }, callback) {
-    // We really only want to load aws-sdk if absolutely necessary
+    // We really only want to load aws-sdk if absolutely necessary, and only the client we need
     // eslint-disable-next-line
-    let aws = require('aws-sdk')
+    let SNS = require('aws-sdk/clients/sns')
 
     function publish (arn, payload, callback) {
-      let sns = new aws.SNS
+      let sns = new SNS
       sns.publish({
         TopicArn: arn,
         Message: JSON.stringify(payload)
@@ -107,12 +107,12 @@ function eventFactory (arc) {
 
 function queueFactory (arc) {
   return function live ({ name, payload, delaySeconds, groupID }, callback) {
-    // We really only want to load aws-sdk if absolutely necessary
+    // We really only want to load aws-sdk if absolutely necessary, and only the client we need
     // eslint-disable-next-line
-    let aws = require('aws-sdk')
+    let SQS = require('aws-sdk/clients/sqs')
 
     function publish (arn, payload, callback) {
-      let sqs = new aws.SQS
+      let sqs = new SQS
       let params = {
         QueueUrl: arn,
         DelaySeconds: delaySeconds || 0,

--- a/src/tables/dynamo.js
+++ b/src/tables/dynamo.js
@@ -4,8 +4,6 @@ let db, doc
 
 /**
  * Instantiates Dynamo service interfaces
- * - Internal APIs should use `db` + `doc` to instantiate DynamoDB interfaces
- * - Avoid using `direct.db` + `direct.doc`: as it's an issue vector for using Functions in certain test harnesses!
  */
 function getDynamo (type, callback) {
   if (!type) throw ReferenceError('Must supply Dynamo service interface type')
@@ -14,13 +12,7 @@ function getDynamo (type, callback) {
   // eslint-disable-next-line
   let dynamo = require('aws-sdk/clients/dynamodb')
 
-  // We might normally like to throw if `local && !port`, but this is also a direct DynamoDB interface in global scope
-  // Thus, this path instantiates even if the project doesn't have tables
-  let {
-    ARC_ENV,
-    ARC_LOCAL,
-    AWS_REGION,
-  } = process.env
+  let { ARC_ENV, ARC_LOCAL, AWS_REGION } = process.env
   let local = ARC_ENV === 'testing' || ARC_LOCAL
   let DB = dynamo
   let Doc = dynamo.DocumentClient
@@ -32,23 +24,16 @@ function getDynamo (type, callback) {
     return callback(null, doc)
   }
 
-  /**
-   * This module may be loaded by @arc/arc via repl
-   * - The `direct` interfaces will instantiate before ARC_ENV is set
-   * - Thus, unlike most other scenarios, don't assume the presence of ARC_ENV
-   * - Also: some test harnesses (ahem) will automatically populate ARC_ENV with their own values, unbidden
-   * - *Why this matters*: using https.Agent (and not http.Agent) will stall the Sandbox
-   */
   if (!local) {
     let agent = new https.Agent({
       keepAlive: true,
       maxSockets: 50, // Node can set to Infinity; AWS maxes at 50; check back on this every once in a while
       rejectUnauthorized: true,
     })
+    // TODO? migrate to using `AWS_NODEJS_CONNECTION_REUSE_ENABLED`?
     let config = {
       httpOptions: { agent }
     }
-    // TODO? migrate to using `AWS_NODEJS_CONNECTION_REUSE_ENABLED`?
 
     if (type === 'db') {
       db = new DB(config)

--- a/src/tables/factory.js
+++ b/src/tables/factory.js
@@ -5,10 +5,9 @@ let parallel = require('run-parallel')
  * returns a data client
  */
 module.exports = function reflectFactory (tables, callback) {
-  let { db, doc } = dynamo
   let local = process.env.ARC_ENV === 'testing'
 
-  parallel({ db, doc }, function done (err, { db, doc }) {
+  parallel(dynamo, function done (err, { db, doc }) {
     if (err) return callback(err)
 
     let data = Object.keys(tables)

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -3,7 +3,7 @@ function instantiateAPI () {
   if (_api) return
   // We really only want to load aws-sdk if absolutely necessary
   // eslint-disable-next-line
-  let { ApiGatewayManagementApi } = require('aws-sdk')
+  let ApiGatewayManagementApi = require('aws-sdk/clients/apigatewaymanagementapi')
   let {
     ARC_ENV,
     ARC_LOCAL,

--- a/test/unit/src/tables/dynamo-test.js
+++ b/test/unit/src/tables/dynamo-test.js
@@ -67,12 +67,13 @@ test('Local port + region configuration', t => {
   })
 
   // Doc x callback
+  // For whatever mysterious reason(s), docs configure their endpoint under doc.service.endpoint, not doc.endpoint
   dynamo.doc((err, doc) => {
     if (err) t.fail(err)
-    t.equal(doc.options.endpoint.host, host, `Doc configured 'host' property is ${host}`)
-    t.equal(doc.options.endpoint.hostname, localhost, `Doc configured 'hostname' property is ${localhost}`)
-    t.equal(doc.options.endpoint.href, `http://${host}/`, `Doc configured 'href' property is http://${host}/`)
-    t.equal(doc.options.endpoint.port, defaultPort, `Doc configured 'port' property is ${defaultPort}`)
+    t.equal(doc.service.endpoint.host, host, `Doc configured 'host' property is ${host}`)
+    t.equal(doc.service.endpoint.hostname, localhost, `Doc configured 'hostname' property is ${localhost}`)
+    t.equal(doc.service.endpoint.href, `http://${host}/`, `Doc configured 'href' property is http://${host}/`)
+    t.equal(doc.service.endpoint.port, defaultPort, `Doc configured 'port' property is ${defaultPort}`)
     t.equal(doc.service.config.region, defaultRegion, `Doc configured 'region' property is ${defaultRegion}`)
   })
 
@@ -102,12 +103,13 @@ test('Local port + region configuration', t => {
   })
 
   // Doc x callback
+  // For whatever mysterious reason(s), docs configure their endpoint under doc.service.endpoint, not doc.endpoint
   dynamo.doc((err, doc) => {
     if (err) t.fail(err)
-    t.equal(doc.options.endpoint.host, host, `Doc configured 'host' property is ${host}`)
-    t.equal(doc.options.endpoint.hostname, localhost, `Doc configured 'hostname' property is ${localhost}`)
-    t.equal(doc.options.endpoint.href, `http://${host}/`, `Doc configured 'href' property is http://${host}/`)
-    t.equal(doc.options.endpoint.port, customPort, `Doc configured 'port' property is ${customPort}`)
+    t.equal(doc.service.endpoint.host, host, `Doc configured 'host' property is ${host}`)
+    t.equal(doc.service.endpoint.hostname, localhost, `Doc configured 'hostname' property is ${localhost}`)
+    t.equal(doc.service.endpoint.href, `http://${host}/`, `Doc configured 'href' property is http://${host}/`)
+    t.equal(doc.service.endpoint.port, customPort, `Doc configured 'port' property is ${customPort}`)
     t.equal(doc.service.config.region, customRegion, `Doc configured 'region' property is ${customRegion}`)
   })
 


### PR DESCRIPTION
Retire `aws-sdk-mock` (84.8MB) for ~15 lines of code

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
