### PR TITLE
chore: add `"sideEffects": false` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.4",
   "description": "Cloud function signatures for HTTP handlers, pub/sub + scheduled, queued functions, table triggers, and more",
   "homepage": "https://github.com/architect/functions",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/architect/functions"


### PR DESCRIPTION
Add `"sideEffects": false` to package.json to allow frameworks that mix client and server code in the same files to tree-shake "@architect/functions" from client bundles.

https://remix.run/docs/en/v1/pages/gotchas#server-code-in-client-bundles

https://esbuild.github.io/api/#conditionally-injecting-a-file
https://webpack.js.org/guides/tree-shaking
https://github.com/rollup/plugins/tree/master/packages/node-resolve#ignoresideeffectsforroot

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
