### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
   },
   "bugs": "https://github.com/architect/functions/issues",
   "main": "src/index",
+  "types": "types",
+  "typings": "types",
   "scripts": {
+    "dtslint": "dtslint types",
     "lint": "eslint --fix .",
     "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-spec",
     "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
-    "test": "npm run lint && npm run test:integration && npm run coverage",
+    "test": "npm run lint && npm run dtslint && npm run test:integration && npm run coverage",
     "rc": "npm version prerelease --preid RC"
   },
   "engines": {
@@ -35,6 +38,8 @@
     "@architect/eslint-config": "1.0.1",
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
     "@architect/sandbox": "^5.2.2",
+    "@definitelytyped/dtslint": "^0.0.112",
+    "@types/node": "^17.0.38",
     "aws-sdk": "2.1001.0",
     "cross-env": "~7.0.3",
     "eslint": "~8.13.0",
@@ -47,7 +52,8 @@
     "tiny-json-http": "~7.4.2"
   },
   "files": [
-    "src/*"
+    "src/*",
+    "types/*"
   ],
   "keywords": [
     "aws",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
     "@architect/sandbox": "^5.2.2",
     "@definitelytyped/dtslint": "^0.0.112",
+    "@types/aws-lambda": "^8.10.98",
     "@types/node": "^17.0.38",
     "aws-sdk": "2.1001.0",
     "cross-env": "~7.0.3",

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -11,7 +11,7 @@ module.exports = function eventsAndQueuesFactory (arc, type) {
      *
      * @param {Object} params
      * @param {String} params.name - the event name (required)
-     * @param {String} params.payload - a json event payload (required)
+     * @param {Object} params.payload - a json event payload (required)
      * @param {Function} callback - a node style errback (optional)
      * @returns {Promise} - returned if no callback is supplied
      */

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -27,5 +27,5 @@ interface EventsOrQueues<PublishResult> {
   ): LambdaFunction;
 }
 
-export type Events = EventsOrQueues<SNS.Types.PublishResponse>;
-export type Queues = EventsOrQueues<SQS.Types.SendMessageResult>;
+export type ArcEvents = EventsOrQueues<SNS.Types.PublishResponse>;
+export type ArcQueues = EventsOrQueues<SQS.Types.SendMessageResult>;

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -1,0 +1,32 @@
+import { SNS, SQS } from "aws-sdk";
+
+// Turn off automatic exporting
+export {};
+
+interface Params<Payload> {
+  name: string;
+  payload: Payload;
+}
+
+type Callback<Res> = (err: Error, res: Res) => void;
+
+// Consumers of this library should not care exactly what this is. Just that
+// it's a lambda function which should be exported as a handler.
+type LambdaFunction = unknown;
+
+interface EventsOrQueues<PublishResult> {
+  publish<Payload = any>(params: Params<Payload>): Promise<PublishResult>;
+  publish<Payload = any>(
+    params: Params<Payload>,
+    callback: Callback<PublishResult>
+  ): void;
+
+  subscribe<Event = any>(
+    handler:
+      | ((event: Event) => Promise<void>)
+      | ((event: Event, callback: Callback<void>) => void)
+  ): LambdaFunction;
+}
+
+export type Events = EventsOrQueues<SNS.Types.PublishResponse>;
+export type Queues = EventsOrQueues<SQS.Types.SendMessageResult>;

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -1,4 +1,5 @@
 import { SNS, SQS } from "aws-sdk";
+import { Callback } from "./util";
 
 // Turn off automatic exporting
 export {};
@@ -7,8 +8,6 @@ interface Params<Payload> {
   name: string;
   payload: Payload;
 }
-
-type Callback<Res> = (err: Error, res: Res) => void;
 
 // Consumers of this library should not care exactly what this is. Just that
 // it's a lambda function which should be exported as a handler.

--- a/types/events.test-d.ts
+++ b/types/events.test-d.ts
@@ -1,0 +1,91 @@
+import arc from "@architect/functions";
+
+interface Payload {
+  some: string;
+}
+
+const event = { name: "some-name", payload: { some: "stuff" } };
+
+async function eventPublishing() {
+  // $ExpectError
+  arc.events.publish({});
+
+  // $ExpectError
+  arc.events.publish<Payload>({ name: "bad", payload: {} });
+
+  // Full type is: SNS.Types.PublishResponse
+  // $ExpectType PublishResponse
+  await arc.events.publish(event);
+
+  arc.events.publish(event, (err, res) => {
+    // $ExpectType Error
+    err;
+
+    // $ExpectType PublishResponse
+    res;
+  });
+}
+
+function eventSubscribing() {
+  arc.events.subscribe(async (event: any) => {
+    // $ExpectType any
+    event;
+  });
+
+  // $ExpectError
+  arc.events.subscribe<Payload>(async (event: number) => {});
+
+  arc.events.subscribe<Payload>(async (event: Payload) => {
+    // $ExpectType Payload
+    event;
+  });
+
+  arc.events.subscribe<Payload>(async (event: Payload, callback) => {
+    // $ExpectType Payload
+    event;
+    // $ExpectType Callback<void>
+    callback;
+  });
+}
+
+async function queuePublishing() {
+  // $ExpectError
+  arc.queues.publish({});
+
+  // $ExpectError
+  arc.queues.publish<Payload>({ name: "bad", payload: {} });
+
+  // Full type is: SQS.Types.SendMessageResult
+  // $ExpectType SendMessageResult
+  await arc.queues.publish(event);
+
+  arc.queues.publish(event, (err, res) => {
+    // $ExpectType Error
+    err;
+
+    // $ExpectType SendMessageResult
+    res;
+  });
+}
+
+function queueSubscribing() {
+  arc.queues.subscribe(async (event: any) => {
+    // $ExpectType any
+    event;
+  });
+
+  // $ExpectError
+  arc.queues.subscribe<Payload>(async (event: number) => {});
+
+  arc.queues.subscribe<Payload>(async (event: Payload) => {
+    // $ExpectType Payload
+    event;
+  });
+
+  arc.queues.subscribe<Payload>(async (event: Payload, callback) => {
+    // $ExpectType Payload
+    event;
+    // $ExpectType Callback<void>
+    callback;
+  });
+}

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -1,0 +1,139 @@
+import {
+  APIGatewayProxyEvent,
+  Context,
+  APIGatewayProxyResult,
+} from "aws-lambda";
+import { Callback } from "./util";
+
+// Turn off automatic exporting
+export {};
+
+export type HttpMethods = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+export type SessionData = Record<string, any>;
+export type JsonBody = any;
+export type HtmlBody = string;
+export type RequestBody = any;
+
+export interface HttpRequest {
+  httpMethod: HttpMethods;
+  /**
+   * The absolute path of the request
+   */
+  path: string;
+
+  /**
+   * The absolute path of the request, with resources substituted for actual path parts (e.g. /{foo}/bar)
+   */
+  resource: string;
+
+  /**
+   * Any URL params, if defined in your HTTP Function's path (e.g. foo in GET /:foo/bar)
+   */
+  pathParameters: Record<string, string>;
+
+  /**
+   * Any query params if present in the client request
+   */
+  queryStringParameters: Record<string, string>;
+
+  /**
+   * All client request headers
+   */
+  headers: Record<string, string>;
+
+  /**
+   * The request body in a base64-encoded buffer. You'll need to parse request.body before you can use it, but Architect provides tools to do this - see parsing request bodies.
+   */
+  body: RequestBody;
+
+  /**
+   * Indicates whether body is base64-encoded binary payload (will always be true if body has not null)
+   */
+  isBase64Encoded: boolean;
+
+  /**
+   * When the request/response is run through arc.http.async (https://arc.codes/docs/en/reference/runtime/node#arc.http.async) then it will have session added.
+   */
+  session?: SessionData | undefined;
+}
+
+export interface HttpResponse {
+  /**
+   * Sets the HTTP status code
+   */
+  statusCode?: number | undefined;
+
+  /**
+   * Alias for @see statusCode
+   */
+  status?: number | undefined;
+
+  /**
+   * All response headers
+   */
+  headers?: Record<string, string> | undefined;
+
+  /**
+   * Contains request body, either as a plain string (no encoding or serialization required) or, if binary, base64-encoded buffer
+   * Note: The maximum body payload size is 6MB
+   */
+  body?: string | undefined;
+
+  /**
+   * Indicates whether body is base64-encoded binary payload
+   * Required to be set to true if emitting a binary payload
+   */
+  isBase64Encoded?: boolean | undefined;
+
+  /**
+   * When the request/response is run through arc.http.async (https://arc.codes/docs/en/reference/runtime/node#arc.http.async) then it will have session added.
+   */
+  session?: SessionData | undefined;
+
+  /**
+   * When used with https://arc.codes/docs/en/reference/runtime/node#arc.http.async
+   * json sets the Content-Type header to application/json
+   */
+  json?: JsonBody | undefined;
+
+  /**
+   * When used with https://arc.codes/docs/en/reference/runtime/node#arc.http.async
+   * json sets the Content-Type header to application/json
+   */
+  html?: HtmlBody | undefined;
+}
+
+type Handler = (
+  req: HttpRequest,
+  res: (resOrError: HttpResponse | Error) => void,
+  next: () => void
+) => void;
+
+type AsyncHandler = (
+  req: HttpRequest,
+  context: Context
+) => Promise<HttpResponse>;
+
+type LambdaHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context
+) => Promise<APIGatewayProxyResult>;
+
+export interface ArcHTTP {
+  (...handlers: Handler[]): LambdaHandler;
+  async: (...handlers: AsyncHandler[]) => LambdaHandler;
+
+  helpers: {
+    bodyParser: (req: HttpRequest) => Record<string, any>;
+    interpolate: (req: HttpRequest) => HttpRequest;
+    url: (url: string) => string;
+  };
+
+  session: {
+    read(req: HttpRequest): Promise<SessionData>;
+    read(req: HttpRequest, callback: Callback<SessionData>): void;
+    write(sess: SessionData): Promise<string>;
+    write(sess: SessionData, callback: Callback<string>): void;
+  };
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,10 +6,12 @@ import { ArcWebSocket } from "./ws";
 import { ArcEvents, ArcQueues } from "./events";
 import { ArcTables } from "./tables";
 
+type ArcServices = () => Promise<Record<string, any>>;
+
 export const http: ArcHTTP;
 export const static: ArcStatic;
-export const ws: ArcWebSocket; // TODO
-export const services: any; // TODO
+export const ws: ArcWebSocket;
+export const services: ArcServices;
 export const events: ArcEvents;
 export const queues: ArcQueues;
 export const tables: ArcTables;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,12 @@
 /// <reference types="node" />
 
 import { ArcHTTP } from "./http";
+import { Static } from "./static";
 import { Events, Queues } from "./events";
 import { ArcTables } from "./tables";
 
 export const http: ArcHTTP;
-export const static: any; // TODO
+export const static: Static;
 export const ws: any; // TODO
 export const services: any; // TODO
 export const events: Events;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+import { ArcTables } from "./tables";
+
+export const tables: ArcTables;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,12 @@
 /// <reference types="node" />
 
+import { Events, Queues } from "./events";
 import { ArcTables } from "./tables";
 
+export const http: any; // TODO
+export const static: any; // TODO
+export const ws: any; // TODO
+export const services: any; // TODO
+export const events: Events;
+export const queues: Queues;
 export const tables: ArcTables;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,10 @@
 /// <reference types="node" />
 
+import { ArcHTTP } from "./http";
 import { Events, Queues } from "./events";
 import { ArcTables } from "./tables";
 
-export const http: any; // TODO
+export const http: ArcHTTP;
 export const static: any; // TODO
 export const ws: any; // TODO
 export const services: any; // TODO

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ import { ArcWebSocket } from "./ws";
 import { ArcEvents, ArcQueues } from "./events";
 import { ArcTables } from "./tables";
 
-type ArcServices = () => Promise<Record<string, any>>;
+export type ArcServices = () => Promise<Record<string, any>>;
 
 export const http: ArcHTTP;
 export const static: ArcStatic;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,14 +1,15 @@
 /// <reference types="node" />
 
 import { ArcHTTP } from "./http";
-import { Static } from "./static";
-import { Events, Queues } from "./events";
+import { ArcStatic } from "./static";
+import { ArcWebSocket } from "./ws";
+import { ArcEvents, ArcQueues } from "./events";
 import { ArcTables } from "./tables";
 
 export const http: ArcHTTP;
-export const static: Static;
-export const ws: any; // TODO
+export const static: ArcStatic;
+export const ws: ArcWebSocket; // TODO
 export const services: any; // TODO
-export const events: Events;
-export const queues: Queues;
+export const events: ArcEvents;
+export const queues: ArcQueues;
 export const tables: ArcTables;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { ArcTables } from "./tables";
 
 export const tables: ArcTables;

--- a/types/static.d.ts
+++ b/types/static.d.ts
@@ -1,0 +1,5 @@
+export interface StaticOptions {
+  stagePath: boolean;
+}
+
+export type Static = (asset: string, options?: StaticOptions) => string;

--- a/types/static.d.ts
+++ b/types/static.d.ts
@@ -2,4 +2,4 @@ export interface StaticOptions {
   stagePath: boolean;
 }
 
-export type Static = (asset: string, options?: StaticOptions) => string;
+export type ArcStatic = (asset: string, options?: StaticOptions) => string;

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -3,21 +3,19 @@ import type { DynamoDB } from "aws-sdk";
 // TableName not needed as the library sets it
 type Params<InputType> = Omit<InputType, "TableName">;
 
-// TableName not needed as the library sets it
-// Plus, we know the type of the returned items
-type Output<OutputType, Item> = Omit<OutputType, "TableName" | "Items"> & {
-  Items: Item;
+// Strip and then override the Items field
+type ItemsOutput<OutputType, Item> = Omit<OutputType, "Items"> & {
+  Items: Item[];
 };
 
 type QueryParams = Params<DynamoDB.DocumentClient.QueryInput>;
-type QueryOutput<Item> = Output<DynamoDB.DocumentClient.QueryOutput, Item>;
+type QueryOutput<Item> = ItemsOutput<DynamoDB.DocumentClient.QueryOutput, Item>;
+
 type ScanParams = Params<DynamoDB.DocumentClient.ScanInput>;
-type ScanOutput<Item> = Output<DynamoDB.DocumentClient.ScanOutput, Item>;
+type ScanOutput<Item> = ItemsOutput<DynamoDB.DocumentClient.ScanOutput, Item>;
+
 type UpdateParams = Params<DynamoDB.DocumentClient.UpdateItemInput>;
-type UpdateOutput<Item> = Output<
-  DynamoDB.DocumentClient.UpdateItemOutput,
-  Item
->;
+type UpdateOutput = DynamoDB.DocumentClient.UpdateItemOutput;
 
 // Depending on the operation, the key attributes may be mandatory, but we don't
 // know what the key attributes are, so Partial is the best we can do.
@@ -41,8 +39,8 @@ export interface ArcTable<Item = unknown> {
   scan(params: ScanParams): Promise<ScanOutput<Item>>;
   scan(params: ScanParams, callback: Callback<ScanOutput<Item>>): void;
 
-  update(params: UpdateParams): Promise<UpdateOutput<Item>>;
-  update(params: UpdateParams, callback: Callback<UpdateOutput<Item>>): void;
+  update(params: UpdateParams): Promise<UpdateOutput>;
+  update(params: UpdateParams, callback: Callback<UpdateOutput>): void;
 }
 
 type DB<Tables> = {
@@ -52,8 +50,8 @@ type DB<Tables> = {
 // Permissive by default: allows any table, any inputs, any outputs.
 type AnyTables = Record<string, any>;
 
-export interface ArcTables<Tables = AnyTables> {
-  (): Promise<DB<Tables>>;
+export interface ArcTables {
+  <Tables = AnyTables>(): Promise<DB<Tables>>;
 
   // legacy methods
   insert: any;

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -1,6 +1,6 @@
 import type { DynamoDB } from "aws-sdk";
 
-// Turns off automatic exporting
+// Turn off automatic exporting
 export {};
 
 // TableName not needed as the library sets it

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -1,0 +1,67 @@
+import type { DynamoDB } from "aws-sdk";
+
+// TableName not needed as the library sets it
+type Params<InputType> = Omit<InputType, "TableName">;
+
+// TableName not needed as the library sets it
+// Plus, we know the type of the returned items
+type Output<OutputType, Item> = Omit<OutputType, "TableName" | "Items"> & {
+  Items: Item;
+};
+
+type QueryParams = Params<DynamoDB.DocumentClient.QueryInput>;
+type QueryOutput<Item> = Output<DynamoDB.DocumentClient.QueryOutput, Item>;
+type ScanParams = Params<DynamoDB.DocumentClient.ScanInput>;
+type ScanOutput<Item> = Output<DynamoDB.DocumentClient.ScanOutput, Item>;
+type UpdateParams = Params<DynamoDB.DocumentClient.UpdateItemInput>;
+type UpdateOutput<Item> = Output<
+  DynamoDB.DocumentClient.UpdateItemOutput,
+  Item
+>;
+
+// Depending on the operation, the key attributes may be mandatory, but we don't
+// know what the key attributes are, so Partial is the best we can do.
+type Key<Item> = Partial<Item>;
+
+type Callback<Res> = (err: Error, res: Res) => void;
+
+export interface ArcTable<Item = unknown> {
+  delete(key: Key<Item>): Promise<{}>;
+  delete(key: Key<Item>, callback: Callback<{}>): void;
+
+  get(key: Key<Item>): Promise<Item>;
+  get(key: Key<Item>, callback: Callback<Item>): void;
+
+  put(item: Item): Promise<{}>;
+  put(item: Item, callback: Callback<{}>): void;
+
+  query(params: QueryParams): Promise<QueryOutput<Item>>;
+  query(params: QueryParams, callback: Callback<QueryOutput<Item>>): void;
+
+  scan(params: ScanParams): Promise<ScanOutput<Item>>;
+  scan(params: ScanParams, callback: Callback<ScanOutput<Item>>): void;
+
+  update(params: UpdateParams): Promise<UpdateOutput<Item>>;
+  update(params: UpdateParams, callback: Callback<UpdateOutput<Item>>): void;
+}
+
+type DB<Tables> = {
+  [tableName in keyof Tables]: ArcTable<Tables[tableName]>;
+};
+
+// Permissive by default: allows any table, any inputs, any outputs.
+type AnyTables = Record<string, any>;
+
+export interface ArcTables<Tables = AnyTables> {
+  (): Promise<DB<Tables>>;
+
+  // legacy methods
+  insert: any;
+  modify: any;
+  update: any;
+  remove: any;
+  destroy: any;
+  all: any;
+  save: any;
+  change: any;
+}

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -1,4 +1,5 @@
 import type { DynamoDB } from "aws-sdk";
+import { Callback } from "./util";
 
 // Turn off automatic exporting
 export {};
@@ -31,8 +32,6 @@ type UpdateOutput = DynamoDB.DocumentClient.UpdateItemOutput;
 // Depending on the operation, the key attributes may be mandatory, but we don't
 // know what the key attributes are, so Partial is the best we can do.
 type Key<Item> = Partial<Item>;
-
-type Callback<Res> = (err: Error, res: Res) => void;
 
 export interface ArcTable<Item = unknown> {
   delete(key: Key<Item>): Promise<{}>;

--- a/types/tables.test-d.ts
+++ b/types/tables.test-d.ts
@@ -1,0 +1,81 @@
+import arc from "@architect/functions";
+
+interface NoteTable {
+  pk: string;
+  title: string;
+}
+
+interface UserTable {
+  pk: string;
+  email: string;
+}
+
+interface MyTables {
+  note: NoteTable;
+  user: UserTable;
+}
+
+async function itIsPermissiveByDefault() {
+  const db = await arc.tables();
+
+  // Table names not checked if you don't provide a type
+  // $ExpectType ArcTable<any>
+  db.blah;
+
+  // You can pass anything, just not *nothing*
+  // $ExpectError
+  db.blah.get();
+
+  // $ExpectType any
+  await db.blah.get({ garbage: "trash" });
+}
+
+async function itEnforcesTableNames() {
+  const db = await arc.tables<MyTables>();
+
+  // $ExpectError
+  db.blah;
+
+  // $ExpectType ArcTable<NoteTable>
+  db.note;
+
+  // $ExpectType ArcTable<UserTable>
+  db.user;
+}
+
+async function itHasTypesForAllMethods() {
+  const db = await arc.tables<MyTables>();
+
+  // $ExpectError
+  await db.note.delete({ garbage: "trash" });
+  // $ExpectType {}
+  await db.note.delete({ pk: "yay" });
+
+  // $ExpectError
+  await db.note.get({ garbage: "trash" });
+  // $ExpectType NoteTable
+  await db.note.get({ pk: "yay" });
+
+  // $ExpectError
+  await db.note.put({ garbage: "trash" });
+  // $ExpectError
+  await db.note.put({ pk: "yay" });
+  // $ExpectType {}
+  await db.note.put({ pk: "yay", title: "finally" });
+
+  // $ExpectError
+  await db.note.query({ garbage: "trash" });
+  // $ExpectType NoteTable[]
+  (await db.note.query({})).Items;
+
+  // $ExpectError
+  await db.note.scan({ garbage: "trash" });
+  // $ExpectType NoteTable[]
+  (await db.note.scan({})).Items;
+
+  // $ExpectError
+  await db.note.update({ garbage: "trash" });
+  // $ExpectError
+  await db.note.update({ Key: { garbage: "trash" } });
+  await db.note.update({ Key: { pk: "yay" } });
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "ES2020",
+    "lib": ["ES6"],
+    "moduleResolution": "node",
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@architect/functions": ["."]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
-    "no-unnecessary-generics": false
+    "no-unnecessary-generics": false,
+    "interface-over-type-literal": false
   }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@definitelytyped/dtslint/dtslint.json",
+  "rules": {
+    "no-unnecessary-generics": false
+  }
+}

--- a/types/util.d.ts
+++ b/types/util.d.ts
@@ -1,0 +1,1 @@
+export type Callback<Res> = (err: Error, res: Res) => void;

--- a/types/ws.d.ts
+++ b/types/ws.d.ts
@@ -1,0 +1,23 @@
+import { ApiGatewayManagementApi } from "aws-sdk";
+import { Callback } from "./util";
+
+// Turn off automatic exporting
+export {};
+
+type SendParams = { id: string; payload: any };
+type CloseParams = { id: string };
+type InfoParams = { id: string };
+type InfoResponse = ApiGatewayManagementApi.Types.GetConnectionResponse;
+
+export interface ArcWebSocket {
+  _api?: ApiGatewayManagementApi;
+
+  send(params: SendParams): Promise<void>;
+  send(params: SendParams, callback: Callback<void>): void;
+
+  close(params: CloseParams): Promise<void>;
+  close(params: CloseParams, callback: Callback<void>): void;
+
+  info(params: InfoParams): Promise<InfoResponse>;
+  info(params: InfoParams, callback: Callback<InfoResponse>): void;
+}


### PR DESCRIPTION
- [x] index.d.ts (started)
- [x] http.d.ts
- [x] static.d.ts
- [x] ws.d.ts
- [x] services.d.ts
- [x] events.d.ts
- [x] queues.d.ts
- [x] tables.d.ts

As discussed in https://github.com/orgs/architect/discussions/1346, this is the beginnings of adding stronger typing to the library. For now it's just the `tables` module, so I can get some feedback, and adjust the approach as needed.

Usage of these types would look something like this:

```ts
import arc from "@architect/functions";

type NoteTable = {
  pk: string;
  sk: string;
  title: string;
  body: string;
};

type UserTable = {
  pk: string;
  email: string;
};

type MyTables = {
  note: NoteTable;
  user: UserTable;
};

async function testingOutTheTypes() {
  const db = await arc.tables<MyTables>();

  // ❌ no such table
  await db.blah.delete();

  // ❌ no such attribute
  await db.note.delete({ blah: 'blah' });

  // ✅
  await db.note.delete({ pk: 'yay' });
};
```

Thoughts so far?