### PR TITLE
improve tables typings

### DIFF
--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -40,7 +40,7 @@ export interface ArcTable<Item = unknown> {
   get(key: Key<Item>): Promise<Item>;
   get(key: Key<Item>, callback: Callback<Item>): void;
 
-  put(item: Item): Promise<{}>;
+  put(item: Item): Promise<Record<string, any>>;
   put(item: Item, callback: Callback<{}>): void;
 
   query(params: QueryParams): Promise<QueryOutput<Item>>;
@@ -53,8 +53,15 @@ export interface ArcTable<Item = unknown> {
   update(params: UpdateParams<Item>, callback: Callback<UpdateOutput>): void;
 }
 
-export type ArcDB<Tables> = {
+type ArcDBWith<Tables> = {
   [tableName in keyof Tables]: ArcTable<Tables[tableName]>;
+};
+
+export type ArcDB<Tables> = ArcDBWith<Tables> & {
+  name(name: string): string;
+  reflect(): object;
+  _db: DynamoDB;
+  _doc: DynamoDB.DocumentClient;
 };
 
 // Permissive by default: allows any table, any inputs, any outputs.

--- a/types/tables.test-d.ts
+++ b/types/tables.test-d.ts
@@ -33,9 +33,9 @@ async function itIsPermissiveByDefault() {
   db.name('note');
   // $ExpectType object
   db.reflect();
-  // $ExpectType AWS.DynamoDB
+  // $ExpectType DynamoDB
   db._db;
-  // $ExpectType AWS.DynamoDB.DocumentClient
+  // $ExpectType DocumentClient
   db._doc;
 }
 
@@ -69,8 +69,9 @@ async function itHasTypesForAllMethods() {
   await db.note.put({ garbage: "trash" });
   // $ExpectError
   await db.note.put({ pk: "yay" });
-  // $ExpectType {}
+  // $ExpectType Record<string, any>
   const newNote = await db.note.put({ pk: "yay", title: "finally" });
+  // $ExpectType any
   newNote.title;
 
   // $ExpectError

--- a/types/tables.test-d.ts
+++ b/types/tables.test-d.ts
@@ -28,6 +28,15 @@ async function itIsPermissiveByDefault() {
 
   // $ExpectType any
   await db.blah.get({ garbage: "trash" });
+
+  // $ExpectType string
+  db.name('note');
+  // $ExpectType object
+  db.reflect();
+  // $ExpectType AWS.DynamoDB
+  db._db;
+  // $ExpectType AWS.DynamoDB.DocumentClient
+  db._doc;
 }
 
 async function itEnforcesTableNames() {
@@ -61,7 +70,8 @@ async function itHasTypesForAllMethods() {
   // $ExpectError
   await db.note.put({ pk: "yay" });
   // $ExpectType {}
-  await db.note.put({ pk: "yay", title: "finally" });
+  const newNote = await db.note.put({ pk: "yay", title: "finally" });
+  newNote.title;
 
   // $ExpectError
   await db.note.query({ garbage: "trash" });


### PR DESCRIPTION
I used an intersection type to add top level methods and attributes to `type ArcDB`.

I also changed the return type for the `put` method to `Record<string, any>` since the Arc client returns the new/updated document. should it be `Item`?

<details closed>

<summary>editor screenshot</summary>

![image](https://user-images.githubusercontent.com/15697/174136639-fc6be6b7-fbd3-44da-9cac-b63c03bce51b.png)

</details>