### PR TITLE
Fix return type on arc.tables.name.put

### DIFF
--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -40,8 +40,8 @@ export interface ArcTable<Item = unknown> {
   get(key: Key<Item>): Promise<Item>;
   get(key: Key<Item>, callback: Callback<Item>): void;
 
-  put(item: Item): Promise<{}>;
-  put(item: Item, callback: Callback<{}>): void;
+  put(item: Item): Promise<Item>;
+  put(item: Item, callback: Callback<Item>): void;
 
   query(params: QueryParams): Promise<QueryOutput<Item>>;
   query(params: QueryParams, callback: Callback<QueryOutput<Item>>): void;

--- a/types/tables.test-d.ts
+++ b/types/tables.test-d.ts
@@ -60,7 +60,7 @@ async function itHasTypesForAllMethods() {
   await db.note.put({ garbage: "trash" });
   // $ExpectError
   await db.note.put({ pk: "yay" });
-  // $ExpectType {}
+  // $ExpectType NoteTable
   await db.note.put({ pk: "yay", title: "finally" });
 
   // $ExpectError


### PR DESCRIPTION
This is a fix for the new types in the current RC, which I implemented and @tbeseda merged.

I previously had `put` returning `{}`, which is incorrect. `put` actually [returns whatever you pass into it](https://github.com/architect/functions/blob/main/src/tables/factory.js#L59). This is now fixed.

### Checklist

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Updated type tests
- [ ] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes