### PR TITLE
fix: ws._api needs to be initialized but there's no method to do it

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -4,6 +4,7 @@
 
 Also see: [Architect changelog](https://github.com/architect/architect/blob/main/changelog.md)
 
+
 ## [x.x.x] 2022-07-23
 
 ### Fixed

--- a/_changelog.md
+++ b/_changelog.md
@@ -4,6 +4,12 @@
 
 Also see: [Architect changelog](https://github.com/architect/architect/blob/main/changelog.md)
 
+## [x.x.x] 2022-07-23
+
+### Fixed
+
+- `ws._api` no longer needs to be initialized by running a websocket function
+
 ---
 
 ## [5.2.1] 2022-06-29

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -102,6 +102,7 @@ module.exports = {
 }
 
 Object.defineProperty(module.exports, '_api', {
+  enumerable: true,
   get () {
     instantiateAPI()
     return _api

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -96,8 +96,14 @@ function info ({ id }, callback) {
 }
 
 module.exports = {
-  _api,
   send,
   close,
   info,
 }
+
+Object.defineProperty(module.exports, '_api', {
+  get () {
+    instantiateAPI()
+    return _api
+  }
+})

--- a/types/ws.d.ts
+++ b/types/ws.d.ts
@@ -10,7 +10,7 @@ type InfoParams = { id: string };
 type InfoResponse = ApiGatewayManagementApi.Types.GetConnectionResponse;
 
 export interface ArcWebSocket {
-  _api?: ApiGatewayManagementApi;
+  _api: ApiGatewayManagementApi;
 
   send(params: SendParams): Promise<void>;
   send(params: SendParams, callback: Callback<void>): void;


### PR DESCRIPTION
`ws._api` starts undefined and the only way to instantiate api is to make an api call. This replaces the export with a getter that calls `instantiateAPI()` so it's always there when you ask for it and now there doesn't need to be a method to instantiate it.

An alternative would be to make a method that returns the api (and maybe eventually remove `ws._api`).

I notice the [docs are wrong](https://github.com/architect/arc.codes/blob/main/src/views/docs/en/reference/runtime-helpers/node.js.md#arcws_api) (the types are right) and will fix that however this one lands.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes
