### PR TITLE
fix(http): update `binaryTypes` array

### DIFF
--- a/src/http/helpers/binary-types.js
+++ b/src/http/helpers/binary-types.js
@@ -19,6 +19,7 @@ module.exports = [
   'font/woff',
   'font/woff2',
   // Images
+  'image/avif',
   'image/bmp',
   'image/gif',
   'image/jpeg',
@@ -32,7 +33,8 @@ module.exports = [
   'audio/basic',
   'audio/mpeg',
   'audio/ogg',
-  'audio/wavaudio/webm',
+  'audio/wav',
+  'audio/webm',
   'audio/x-aiff',
   'audio/x-midi',
   'audio/x-wav',


### PR DESCRIPTION
Brought in line with the changes we did in the Remix repo:

- https://github.com/remix-run/remix/blob/534e1ec071f17654a4db8622e30d6ff70548ce26/packages/remix-architect/binaryTypes.ts#L23
- https://github.com/remix-run/remix/blob/534e1ec071f17654a4db8622e30d6ff70548ce26/packages/remix-architect/binaryTypes.ts#L37-L38
