### PR TITLE
perf(http) Improve IsBinary checking performance

### DIFF
--- a/src/http/_res-fmt.js
+++ b/src/http/_res-fmt.js
@@ -2,8 +2,6 @@ let httpError = require('./errors')
 let binaryTypes = require('./helpers/binary-types')
 let { brotliCompressSync } = require('zlib')
 
-let binaryTypesSet = new Set(binaryTypes)
-
 module.exports = function responseFormatter (req, params) {
   let isError = params instanceof Error
 
@@ -170,7 +168,7 @@ module.exports = function responseFormatter (req, params) {
 
   // Handle body encoding (if necessary)
   let [ cTest ] = (res.headers['content-type'] || '').split(';')
-  let isBinary = binaryTypesSet.has(cTest)
+  let isBinary = binaryTypes.includes(cTest)
   let bodyIsString = typeof res.body === 'string'
   let b64enc = i => new Buffer.from(i).toString('base64')
   function compress (body) {

--- a/src/http/_res-fmt.js
+++ b/src/http/_res-fmt.js
@@ -2,6 +2,8 @@ let httpError = require('./errors')
 let binaryTypes = require('./helpers/binary-types')
 let { brotliCompressSync } = require('zlib')
 
+let binaryTypesSet = new Set(binaryTypes)
+
 module.exports = function responseFormatter (req, params) {
   let isError = params instanceof Error
 
@@ -167,7 +169,8 @@ module.exports = function responseFormatter (req, params) {
   }
 
   // Handle body encoding (if necessary)
-  let isBinary = binaryTypes.some(t => res.headers['content-type'].includes(t))
+  let [ cTest ] = (res.headers['content-type'] || '').split(';')
+  let isBinary = binaryTypesSet.has(cTest)
   let bodyIsString = typeof res.body === 'string'
   let b64enc = i => new Buffer.from(i).toString('base64')
   function compress (body) {


### PR DESCRIPTION
Hello,

While browsing the remix project, I noticed that the control of the "Content-Type" header which allows to know if the body is binary could be improved. It is also possible to apply this change in this project.

Indeed, the check on the value of the header is done using an iteration on the array and a test for the presence of string with the Array.includes method. 
This implies a complexity of O(TypesCount*IncludesComplexity). It would be more efficient to use Set.has because the complexity would be O(1).

Related remix PR : https://github.com/remix-run/remix/pull/4761