### PR TITLE
v7 types update

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/lib-dynamodb": "^3.319.0",
     "@aws-sdk/node-http-handler": "^3.347.0",
     "@types/aws-lambda": "^8.10.119",
-    "@types/node": "^20.4.1",
+    "@types/node": "18",
     "aws-sdk": "^2.1364.0",
     "cross-env": "~7.0.3",
     "eslint": "^8.44.0",

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -81,7 +81,7 @@ type Handler = (
 type AsyncHandler = (
   req: HttpRequest,
   context: Context,
-) => Promise<HttpResponse>;
+) => Promise<HttpResponse | void>;
 
 type LambdaHandler = (
   event: APIGatewayProxyEvent,

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -9,11 +9,8 @@ import { Callback } from "./util";
 export { };
 
 export type HttpMethods = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
-
+export type ApiGatewayRequestVersion = "1.0" | "2.0" | string;
 export type SessionData = Record<string, any>;
-export type JsonBody = any;
-export type HtmlBody = string;
-export type RequestBody = any;
 
 export interface HttpRequest {
   httpMethod: HttpMethods;
@@ -28,11 +25,16 @@ export interface HttpRequest {
   /** All client request headers */
   headers: Record<string, string>;
   /** The request body in a base64-encoded buffer. You'll need to parse request.body before you can use it, but Architect provides tools to do this - see parsing request bodies. */
-  body: RequestBody;
+  body: any;
   /** Indicates whether body is base64-encoded binary payload (will always be true if body has not null) */
   isBase64Encoded: boolean;
   /** When the request/response is run through arc.http.async (https://arc.codes/docs/en/reference/runtime/node#arc.http.async) then it will have session added. */
   session?: SessionData | undefined;
+  version: ApiGatewayRequestVersion;
+  rawBody: string;
+  method: HttpMethods;
+  params: Record<string, string>;
+  query: Record<string, string>;
 }
 
 export interface HttpResponse {
@@ -58,12 +60,16 @@ export interface HttpResponse {
    * When used with https://arc.codes/docs/en/reference/runtime/node#arc.http.async
    * json sets the Content-Type header to application/json
    */
-  json?: JsonBody | undefined;
+  json?: any | undefined;
   /**
    * When used with https://arc.codes/docs/en/reference/runtime/node#arc.http.async
    * json sets the Content-Type header to application/json
    */
-  html?: HtmlBody | undefined;
+  html?: string | undefined;
+  css?: string | undefined;
+  js?: string | undefined;
+  text?: string | undefined;
+  xml?: string | undefined;
 }
 
 type Handler = (

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -72,13 +72,13 @@ export interface HttpResponse {
   xml?: string | undefined;
 }
 
-type Handler = (
+export type HttpHandler = (
   req: HttpRequest,
   res: (resOrError: HttpResponse | Error) => void,
   next: () => void,
 ) => void;
 
-type AsyncHandler = (
+export type HttpAsyncHandler = (
   req: HttpRequest,
   context: Context,
 ) => Promise<HttpResponse | void>;
@@ -89,8 +89,9 @@ type LambdaHandler = (
 ) => Promise<APIGatewayProxyResult>;
 
 export interface ArcHTTP {
-  (...handlers: Handler[]): LambdaHandler;
-  async: (...handlers: AsyncHandler[]) => LambdaHandler;
+  (...handlers: HttpHandler[]): LambdaHandler;      // these method signatures are the same
+  (...handlers: HttpAsyncHandler[]): LambdaHandler; // unable to overload gracefully
+  async: (...handlers: HttpAsyncHandler[]) => LambdaHandler;
   helpers: {
     bodyParser: (req: HttpRequest) => Record<string, any>;
     interpolate: (req: HttpRequest) => HttpRequest;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,12 @@
 /// <reference types="node" />
 
-import { ArcHTTP } from "./http";
+import { ArcHTTP, HttpHandler, HttpAsyncHandler } from "./http";
 import { ArcStatic } from "./static";
 import { ArcWebSocket } from "./ws";
 import { ArcEvents, ArcQueues } from "./events";
 import { ArcTables } from "./tables";
 
+export type { HttpHandler, HttpAsyncHandler };
 export type ArcServices = () => Promise<Record<string, any>>;
 
 export const http: ArcHTTP;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,8 +1,9 @@
 import { ApiGatewayManagementApi, DynamoDB, SNS, SQS } from "aws-sdk";
 import { Context } from "aws-lambda";
 import { expectType, expectAssignable, expectNotAssignable } from "tsd";
-import type { HttpMethods, HttpRequest, HttpResponse, HttpHandler, HttpAsyncHandler } from "./http";
 import arc from "../";
+import type { HttpHandler, HttpAsyncHandler } from "../"
+import type { HttpMethods, HttpRequest, HttpResponse } from "./http";
 
 // EVENTS
 const eventsPublishArg = { name: "test", payload: { foo: "bar" } };

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -36,13 +36,18 @@ arc.http.async(async function (request, context) {
 });
 const sampleRequest = {
   httpMethod: "POST" as HttpMethods,
+  method: "POST" as HttpMethods,
   path: "/",
   resource: "",
   pathParameters: { foo: "bar" },
+  params: { foo: "bar" },
   queryStringParameters: { bar: "baz" },
+  query: { bar: "baz" },
   headers: { accept: "any" },
   body: "undefined",
+  rawBody: "undefined",
   isBase64Encoded: false,
+  version: "42",
 };
 expectType<Record<string, any>>(arc.http.helpers.bodyParser(sampleRequest));
 expectType<HttpRequest>(arc.http.helpers.interpolate(sampleRequest));
@@ -72,6 +77,10 @@ await myTable.query({
   ExpressionAttributeValues: { ':bar': 'baz' },
 })
 await myTable.scan({
+  FilterExpression: 'radness > :ninethousand',
+  ExpressionAttributeValues: { ':ninethousand': 9000 },
+})
+await myTable.scanAll({
   FilterExpression: 'radness > :ninethousand',
   ExpressionAttributeValues: { ':ninethousand': 9000 },
 })

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -49,6 +49,8 @@ export interface ArcTable<Item = unknown> {
   scan(params: ScanParams): Promise<ScanOutput<Item>>;
   scan(params: ScanParams, callback: Callback<ScanOutput<Item>>): void;
 
+  scanAll(params: ScanParams): Promise<Item[]>;
+
   update(params: UpdateParams<Item>): Promise<UpdateOutput>;
   update(params: UpdateParams<Item>, callback: Callback<UpdateOutput>): void;
 }


### PR DESCRIPTION
alternative to https://github.com/architect/functions/pull/550

Typings for new Architect Functions v7 features as well as some minor fixes for missing features in HTTPRequests and "middleware" return types.

## still todo:

- [x] let `arc.http` handle both callback and async-style handlers
- [x] `table.scanAll`
- [x] expand HTTPRequest type
- [x] allow middleware to return `void`

## comment on .d.ts vs JSDoc:

Unfortunately, I don't think the JSDoc approach for a consumed library with complex types is sustainable right now. The TS lang server (used by most modern editors to parse _Javascript_ files) is inconsistent in how it interprets doc comments and bubbles those types to the end user/developer working with Arc.

So for now, I still recommend keeping a types/ dir with exported types written in TS and tested with a simple .test-d.ts file.