### PR TITLE
Fix events.subscribe types: returns either an async or promise function

### DIFF
--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -10,21 +10,14 @@ interface Params<Payload> {
   payload: Payload;
 }
 
-// Consumers of this library should not care exactly what this is. Just that
-// it's a lambda function which should be exported as a handler.
-type LambdaFunction = unknown;
-
 interface EventsOrQueues<PublishResult> {
   publish<Payload = any>(params: Params<Payload>): Promise<PublishResult>;
   publish<Payload = any>(
     params: Params<Payload>,
     callback: Callback<PublishResult>,
   ): void;
-  subscribe<Event = any>(
-    handler:
-      | ((event: Event) => Promise<void>)
-      | ((event: Event, callback: Callback<void>) => void),
-  ): LambdaFunction;
+  subscribe<Event = any>(handler: (e: Event) => Promise<void>): (e: Event) => Promise<void>;
+  subscribe<Event = any>(handler: (e: Event, callback: Function) => void): (e: Event, context: any, callback: Function) => void;
 }
 
 export type ArcEvents = EventsOrQueues<SnsPublishResponse>;


### PR DESCRIPTION
Returning `unknown` from `events.subscribe`, as the types do today, sucks if you're writing tests:

<img width="964" alt="Screenshot 2024-08-17 at 17 22 08" src="https://github.com/user-attachments/assets/30c72aae-c772-4bf8-9c23-986a98ff4b49">

This PR attempts to address this by tweaking the return type of `subscribe`, which is conditional based on what kind of event handler function you pass into `subscribe`:

1. [If you pass an async function, `subscribe` returns an async function](https://github.com/architect/functions/blob/main/src/events/subscribe.js#L25-L26).
2. [If you pass it a regular function that accepts two parameters, the second parameter being a callback, it returns a regular function that takes three parameters, the last being a callback too](https://github.com/architect/functions/blob/main/src/events/subscribe.js#L44-L45).

With these changes, now my tests are tidier with less IDE complaints. With an async handler the result looks like:

<img width="413" alt="Screenshot 2024-08-17 at 17 19 33" src="https://github.com/user-attachments/assets/d44e85d5-9ee8-4533-9e8f-de871b26bc1e">


.. and using a callback interface, too:

<img width="571" alt="Screenshot 2024-08-17 at 17 18 52" src="https://github.com/user-attachments/assets/0692a835-4114-4c01-baaf-1e895b76291e">

No matter which style of handler you pass, at least in the context of my tests, now my IDE knows that I am dealing with functions - even the right kinds to boot!