### PR TITLE
Mark `scan()` and `scanAll()` parameters as optional

### DIFF
--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -49,7 +49,8 @@ export interface ArcTable<Item = unknown> {
   query(params: QueryParams, callback: Callback<QueryOutput<Item>>): void;
 
   scan(params?: ScanParams): Promise<ScanOutput<Item>>;
-  scan(params?: ScanParams, callback: Callback<ScanOutput<Item>>): void;
+  scan(params: ScanParams, callback: Callback<ScanOutput<Item>>): void;
+  scan(callback: Callback<ScanOutput<Item>>): void;
 
   scanAll(params?: ScanParams): Promise<Item[]>;
 

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -48,10 +48,10 @@ export interface ArcTable<Item = unknown> {
   query(params: QueryParams): Promise<QueryOutput<Item>>;
   query(params: QueryParams, callback: Callback<QueryOutput<Item>>): void;
 
-  scan(params: ScanParams): Promise<ScanOutput<Item>>;
-  scan(params: ScanParams, callback: Callback<ScanOutput<Item>>): void;
+  scan(params?: ScanParams): Promise<ScanOutput<Item>>;
+  scan(params?: ScanParams, callback: Callback<ScanOutput<Item>>): void;
 
-  scanAll(params: ScanParams): Promise<Item[]>;
+  scanAll(params?: ScanParams): Promise<Item[]>;
 
   update(params: UpdateParams<Item>): AwsLiteDynamoDB["UpdateItem"];
   update(params: UpdateParams<Item>, callback: Callback<UpdateItemResponse>): void;


### PR DESCRIPTION
The documentation for the `scan()` and `scanAll()` methods (https://arc.codes/docs/en/reference/runtime-helpers/node.js#instance-methods) say that the parameters are optional. However, this isn't reflected in the type definitions. This PR fixes that.
