### PR TITLE
Add TablesOptions type to tables.d.ts

### DIFF
--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -77,19 +77,19 @@ type AnyTables = Record<string, any>;
 
 type TablesOptions = {
   awsjsonMarshall?: {
-    allowImpreciseNumbers?: bool,
-    convertClassInstanceToMap?: bool,
-    convertEmptyValues?: bool,
-    convertTopLevelContainer?: bool,
-    removeUndefinedValues?: bool
+    allowImpreciseNumbers?: boolean,
+    convertClassInstanceToMap?: boolean,
+    convertEmptyValues?: boolean,
+    convertTopLevelContainer?: boolean,
+    removeUndefinedValues?: boolean
   },
   awsjsonUnmarshall?: {
-    convertWithoutMapWrapper?: bool,
-    wrapNumbers?: bool | ((value:string) => number | bigint | any)
+    convertWithoutMapWrapper?: boolean,
+    wrapNumbers?: boolean | ((value:string) => number | bigint | any)
   }
 };
 
-export interface ArcTables {
+export interface ArcTables{ 
   <Tables = AnyTables>(options?: TablesOptions): Promise<ArcDB<Tables>>;
 
   // legacy methods

--- a/types/tables.d.ts
+++ b/types/tables.d.ts
@@ -75,8 +75,22 @@ export type ArcDB<Tables> = ArcDBWith<Tables> & {
 // Permissive by default: allows any table, any inputs, any outputs.
 type AnyTables = Record<string, any>;
 
+type TablesOptions = {
+  awsjsonMarshall?: {
+    allowImpreciseNumbers?: bool,
+    convertClassInstanceToMap?: bool,
+    convertEmptyValues?: bool,
+    convertTopLevelContainer?: bool,
+    removeUndefinedValues?: bool
+  },
+  awsjsonUnmarshall?: {
+    convertWithoutMapWrapper?: bool,
+    wrapNumbers?: bool | ((value:string) => number | bigint | any)
+  }
+};
+
 export interface ArcTables {
-  <Tables = AnyTables>(): Promise<ArcDB<Tables>>;
+  <Tables = AnyTables>(options?: TablesOptions): Promise<ArcDB<Tables>>;
 
   // legacy methods
   insert: any;


### PR DESCRIPTION
This adds TablesOptions to the ArcTables types. This should surface the options to users that need to drop down into `tables._client` and need to set up the options.
