### PR TITLE
chore: move to oidc npm publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
         os: [ windows-latest, ubuntu-latest, macOS-latest ]
 
     # Go
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -40,14 +40,7 @@ jobs:
     - name: Install
       run: npm install
 
-    - name: Test (Node.js <= 16.x)
-      if: matrix.node-version <= '16.x'
-      run: npm run test:nolint
-      env:
-        CI: true
-
     - name: Test
-      if: matrix.node-version > '16.x'
       run: npm test
       env:
         CI: true
@@ -72,6 +65,9 @@ jobs:
   # Publish to package registries
   publish:
     # Setup
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -79,26 +75,22 @@ jobs:
     # Go
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
 
       # Publish to npm
       - name: Publish @RC to npm
         if: contains(github.ref, 'RC')
         run: npm publish --tag RC
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @latest to npm
         if: contains(github.ref, 'RC') == false #'!contains()'' doesn't work lol
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Notify
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
Trusted publisher already set up in https://www.npmjs.com/package/@architect/functions/access.